### PR TITLE
Fix/77 : 예외처리를 위한 조건문 추가

### DIFF
--- a/src/test/java/com/example/cs25/batch/jobs/DailyMailSendJobTest.java
+++ b/src/test/java/com/example/cs25/batch/jobs/DailyMailSendJobTest.java
@@ -81,6 +81,10 @@ class DailyMailSendJobTest {
 
     @Test
     void 대량메일발송_MQ비동기_성능측정() throws Exception {
+
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start("mailJob");
+
         //given
         for (int i = 0; i < 1000; i++) {
             Map<String, String> data = Map.of(
@@ -96,9 +100,6 @@ class DailyMailSendJobTest {
             .addLong("timestamp", System.currentTimeMillis())
             .toJobParameters();
 
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start("mailJob");
-
         JobExecution execution = jobLauncher.run(mailJob, params);
         stopWatch.stop();
 
@@ -106,9 +107,10 @@ class DailyMailSendJobTest {
         long totalMillis = stopWatch.getTotalTimeMillis();
         long count = execution.getStepExecutions().stream()
             .mapToLong(StepExecution::getWriteCount).sum();
+        long avgMillis = (count == 0) ? totalMillis : totalMillis / count;
         System.out.println("배치 종료 상태: " + execution.getExitStatus());
         System.out.println("총 발송 시간(ms): " + totalMillis);
         System.out.println("총 발송 시도) " + count);
-        System.out.println("평균 시간(ms): " + totalMillis/count);
+        System.out.println("평균 시간(ms): " + avgMillis);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 테스트 코드 0으로 나뉠 때의 예외 처리 조건문 추가

closed #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 메일 발송 성능 측정 테스트에서 타이머 시작 시점을 데이터 준비 전으로 조정하였습니다.
  - 발송 메일 수가 0일 때 평균 시간 계산에서 오류가 발생하지 않도록 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->