### PR TITLE
fix: aiFeedback 컬럼 데이터길이 수정

### DIFF
--- a/src/main/java/com/example/cs25/domain/userQuizAnswer/entity/UserQuizAnswer.java
+++ b/src/main/java/com/example/cs25/domain/userQuizAnswer/entity/UserQuizAnswer.java
@@ -4,6 +4,8 @@ import com.example.cs25.domain.quiz.entity.Quiz;
 import com.example.cs25.domain.subscription.entity.Subscription;
 import com.example.cs25.domain.users.entity.User;
 import com.example.cs25.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,7 +28,10 @@ public class UserQuizAnswer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String userAnswer;
+
+    @Column(columnDefinition = "TEXT")
     private String aiFeedback;
+
     private Boolean isCorrect;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 🔎 작업 내용

- `UserQuizAnswer` 엔티티에 `aiFeedback` 컬럼 데이터 길이 수정

---

## 🧩 트러블 슈팅

- 배치서버 실행 시, `aiFeedback` 컬럼 데이터 길이 초과 에러 발생

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 데이터베이스에서 aiFeedback 필드가 더 긴 문자열을 저장할 수 있도록 저장 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->