### PR TITLE
Refactor: 구독설정(수정) 프론트 페이지와 연결 로직 수정

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/QuizCategory.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/QuizCategory.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor
-@AllArgsConstructor
 public class QuizCategory extends BaseEntity {
 
     @Id

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/Subscription.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/Subscription.java
@@ -88,13 +88,17 @@ public class Subscription extends BaseEntity {
     /**
      * 사용자가 입력한 값으로 구독정보를 업데이트하는 메서드
      *
-     * @param subscription 사용자를 통해 받은 구독 정보
+     * @param category 퀴즈 카테고리
+     * @param days 구독 요일 정보
+     * @param isActive 활성화 상태
+     * @param period 기간 연장 정보
      */
-    public void update(Subscription subscription) {
-        this.category = subscription.getCategory();
-        this.subscriptionType = subscription.subscriptionType;
-        this.isActive = subscription.isActive;
-        this.endDate = subscription.endDate;
+    public void update(QuizCategory category, Set<DayOfWeek> days,
+                                 boolean isActive, SubscriptionPeriod period) {
+        this.category = category;
+        this.subscriptionType = encodeDays(days);
+        this.isActive = isActive;
+        this.endDate = this.endDate.plusMonths(period.getMonths());
     }
 
     /**

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/SubscriptionPeriod.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/SubscriptionPeriod.java
@@ -1,5 +1,7 @@
 package com.example.cs25entity.domain.subscription.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,5 +14,20 @@ public enum SubscriptionPeriod {
     SIX_MONTHS(6),
     ONE_YEAR(12);
 
-    private final int months;
+    private final long months;
+
+    @JsonValue
+    public long getMonths() {
+        return months;
+    }
+
+    @JsonCreator
+    public static SubscriptionPeriod fromMonths(long months) {
+        for (SubscriptionPeriod period : values()) {
+            if (period.months == months) {
+                return period;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 SubscriptionPeriod 입니다.: " + months);
+    }
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/exception/SubscriptionExceptionCode.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/exception/SubscriptionExceptionCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum SubscriptionExceptionCode {
-    ILLEGAL_SUBSCRIPTION_PERIOD_ERROR(false, HttpStatus.BAD_REQUEST, "지원하지 않는 구독기간입니다."),
+    ILLEGAL_SUBSCRIPTION_PERIOD_ERROR(false, HttpStatus.BAD_REQUEST, "구독 시작일로부터 1년 이상 구독할 수 없습니다."),
     ILLEGAL_SUBSCRIPTION_TYPE_ERROR(false, HttpStatus.BAD_REQUEST, "요일 값이 비정상적입니다."),
     NOT_FOUND_SUBSCRIPTION_ERROR(false, HttpStatus.NOT_FOUND, "구독 정보를 불러올 수 없습니다."),
     DUPLICATE_SUBSCRIPTION_EMAIL_ERROR(false, HttpStatus.CONFLICT, "이미 구독중인 이메일입니다.");

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/controller/SubscriptionController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/controller/SubscriptionController.java
@@ -3,14 +3,13 @@ package com.example.cs25service.domain.subscription.controller;
 import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
-import com.example.cs25service.domain.subscription.dto.SubscriptionRequest;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionResponseDto;
 import com.example.cs25service.domain.subscription.service.SubscriptionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +37,7 @@ public class SubscriptionController {
 
     @PostMapping
     public ApiResponse<SubscriptionResponseDto> createSubscription(
-        @RequestBody @Valid SubscriptionRequest request,
+        @RequestBody @Valid SubscriptionRequestDto request,
         @AuthenticationPrincipal AuthUser authUser
     ) {
         SubscriptionResponseDto subscription = subscriptionService.createSubscription(request,
@@ -56,7 +55,7 @@ public class SubscriptionController {
     @PatchMapping("/{subscriptionId}")
     public ApiResponse<Void> updateSubscription(
         @PathVariable(name = "subscriptionId") Long subscriptionId,
-        @ModelAttribute @Valid SubscriptionRequest request
+        @RequestBody @Valid SubscriptionRequestDto request
     ) {
         subscriptionService.updateSubscription(subscriptionId, request);
         return new ApiResponse<>(200);

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/dto/SubscriptionInfoDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/dto/SubscriptionInfoDto.java
@@ -1,19 +1,24 @@
 package com.example.cs25service.domain.subscription.dto;
 
 import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.time.LocalDate;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 @Builder
+@RequiredArgsConstructor
+@JsonPropertyOrder({"category", "email", "days", "active", "startDate", "endDate", "period"})
 public class SubscriptionInfoDto {
-
-    private final String category;
-
-    private final Long period;
-
-    private final Set<DayOfWeek> subscriptionType;
+    private final String category; // 구독 카테고리
+    private final String email; // 구독 이메일
+    private final Set<DayOfWeek> days; // 구독하고 있는 요일
+    private final boolean active; // 구독 활성화 여부
+    private final LocalDate startDate; // 구독 시작 일자
+    private final LocalDate endDate; // 구독 종료 일자
+    private final long period; // 구독 중인 기간
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/dto/SubscriptionRequestDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/dto/SubscriptionRequestDto.java
@@ -9,33 +9,31 @@ import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
-public class SubscriptionRequest {
+public class SubscriptionRequestDto {
 
-    @NotNull(message = "기술 분야 선택은 필수입니다.")
+    @NotNull(message = "분야 선택은 필수입니다.")
     private String category;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
-    @NotEmpty(message = "구독주기는 한 개 이상 선택해야 합니다.")
+    @NotEmpty(message = "요일은 반드시 한 개 이상 선택해야 합니다.")
     private Set<DayOfWeek> days;
 
-    private boolean isActive;
+    private boolean active;
 
     // 수정하면서 기간을 늘릴수도, 안늘릴수도 있음, 기본값은 0
-    @NotNull
+    @NotNull(message = "구독기간연장 값이 올바르지 않습니다.")
     private SubscriptionPeriod period;
 
     @Builder
-    public SubscriptionRequest(SubscriptionPeriod period, boolean isActive, Set<DayOfWeek> days,
+    public SubscriptionRequestDto(SubscriptionPeriod period, boolean active, Set<DayOfWeek> days,
         String email, String category) {
         this.period = period;
-        this.isActive = isActive;
+        this.active = active;
         this.days = days;
         this.email = email;
         this.category = category;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
@@ -1,5 +1,7 @@
 package com.example.cs25service.domain.subscription.service;
 
+import static com.example.cs25entity.domain.subscription.entity.Subscription.*;
+
 import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
@@ -14,7 +16,7 @@ import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
 import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
-import com.example.cs25service.domain.subscription.dto.SubscriptionRequest;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionResponseDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -50,9 +52,12 @@ public class SubscriptionService {
         long period = ChronoUnit.DAYS.between(start, end);
 
         return SubscriptionInfoDto.builder()
-            .subscriptionType(Subscription.decodeDays(
-                subscription.getSubscriptionType()))
             .category(subscription.getCategory().getCategoryType())
+            .email(subscription.getEmail())
+            .days(decodeDays(subscription.getSubscriptionType()))
+            .active(subscription.isActive())
+            .startDate(subscription.getStartDate())
+            .endDate(subscription.getEndDate())
             .period(period)
             .build();
     }
@@ -64,7 +69,7 @@ public class SubscriptionService {
      */
     @Transactional
     public SubscriptionResponseDto createSubscription(
-        SubscriptionRequest request,
+        SubscriptionRequestDto request,
         AuthUser authUser) {
 
         // 퀴즈 카테고리 불러오기
@@ -142,14 +147,28 @@ public class SubscriptionService {
      * 구독정보를 업데이트하는 메서드
      *
      * @param subscriptionId 구독 아이디
-     * @param request        사용자로부터 받은 업데이트할 구독정보
+     * @param requestDto 사용자로부터 받은 업데이트할 구독정보
      */
     @Transactional
     public void updateSubscription(Long subscriptionId,
-        SubscriptionRequest request) {
+        SubscriptionRequestDto requestDto) {
         Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
+        QuizCategory quizCategory = quizCategoryRepository.findByCategoryTypeOrElseThrow(
+            requestDto.getCategory());
 
-        subscription.update(subscription);
+        LocalDate requestDate = subscription.getEndDate().plusMonths(requestDto.getPeriod().getMonths());
+        LocalDate maxSubscriptionDate = subscription.getStartDate().plusYears(1);
+        if(requestDate.isAfter(maxSubscriptionDate)){
+            throw new SubscriptionException(SubscriptionExceptionCode.ILLEGAL_SUBSCRIPTION_PERIOD_ERROR);
+        }
+
+        subscription.update(
+            quizCategory,
+            requestDto.getDays(),
+            requestDto.isActive(),
+            requestDto.getPeriod()
+        );
+
         createSubscriptionHistory(subscription);
     }
 


### PR DESCRIPTION
## 🔎 작업 내용

- 구독설정 프론트 페이지와 연결되는 로직 수정

---

## 🛠️ 변경 사항

- `QuizCategory`에 불필요한 어노테이션 `@AllArgsConstructor` 삭제
- `SubscriptionExceptionCode` 메시지 수정
- `SubscriptionInfoDto` 필드 추가
- `SubscriptionPeriod` 클래스 JSON 역직렬화 & 직렬화 코드 추가
- `Subscription` 엔티티의 `update()` 메서드를 Service단에서도 사용할 수 있게 수정

---

## 🧩 트러블 슈팅

- `isActive` 필드는 프론트에서 `active`로 바뀐다...
  - `SubscriptionInfoDto` 클래스에서 `isActive` 필드가 있는데, `Jackson(JSON 직렬화 라이브러리)`은 
  기본적으로 `"isActive" → "active"`로 필드 이름을 변환하여 JSON에 포함시킵니다.
  이유는 Java Bean 표준에서 isXxx() 형식의 getter는 xxx라는 속성으로 인식하기 때문
- 프론트에서 `period` 필드값으로 3을 주면 6개월이 추가되는 마법
   - JSON 역직렬화 작업을 안해줬기에 `SubscriptionPeriod`의 3번째 값인 6개월이 설정되는 것..
---

## 📌 참고 사항

- 운영서버에는 데이터가 피료해

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 구독 정보에 이메일, 요일, 활성화 상태, 시작일, 종료일 등 추가 정보가 제공됩니다.

- **버그 수정**
  - 구독 요청 및 수정 시 DTO 클래스명과 필드명이 일관성 있게 변경되었습니다.
  - 구독 기간 필드의 타입이 long으로 변경되어 더 긴 기간도 정확하게 처리할 수 있습니다.

- **개선 사항**
  - 구독 기간이 1년을 초과할 수 없도록 제한이 적용되었습니다.
  - 구독 관련 요청의 유효성 메시지가 더 명확하게 개선되었습니다.
  - 구독 요청 시 JSON 형식으로만 데이터를 받도록 변경되었습니다.

- **스타일**
  - JSON 응답 필드 순서가 명확하게 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->