### PR TITLE
Feat/121 관리자 유저 CRUD, Oauth2 로그인 예외 분기 추가

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/Quiz.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/Quiz.java
@@ -53,7 +53,7 @@ public class Quiz extends BaseEntity {
 
     @Builder
     public Quiz(QuizFormatType type, String question, String answer, String commentary,
-        String choice, QuizCategory category, QuizLevel level, boolean isDeleted) {
+        String choice, QuizCategory category, QuizLevel level) {
         this.type = type;
         this.question = question;
         this.choice = choice;
@@ -61,7 +61,7 @@ public class Quiz extends BaseEntity {
         this.commentary = commentary;
         this.category = category;
         this.level = level;
-        this.isDeleted = isDeleted;
+        this.isDeleted = false;
     }
 
     public void updateCategory(QuizCategory quizCategory) {
@@ -91,5 +91,13 @@ public class Quiz extends BaseEntity {
     public void updateType(QuizFormatType type) {
         this.type = type;
         updateChoice(this.choice);
+    }
+
+    public void disableQuiz() {
+        this.isDeleted = true;
+    }
+
+    public void enableQuiz() {
+        this.isDeleted = false;
     }
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/Quiz.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/Quiz.java
@@ -93,11 +93,11 @@ public class Quiz extends BaseEntity {
         updateChoice(this.choice);
     }
 
-    public void disableQuiz() {
+    public void enableQuiz() {
         this.isDeleted = true;
     }
 
-    public void enableQuiz() {
+    public void disableQuiz() {
         this.isDeleted = false;
     }
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/Subscription.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/subscription/entity/Subscription.java
@@ -89,12 +89,12 @@ public class Subscription extends BaseEntity {
      * 사용자가 입력한 값으로 구독정보를 업데이트하는 메서드
      *
      * @param category 퀴즈 카테고리
-     * @param days 구독 요일 정보
+     * @param days     구독 요일 정보
      * @param isActive 활성화 상태
-     * @param period 기간 연장 정보
+     * @param period   기간 연장 정보
      */
     public void update(QuizCategory category, Set<DayOfWeek> days,
-                                 boolean isActive, SubscriptionPeriod period) {
+        boolean isActive, SubscriptionPeriod period) {
         this.category = category;
         this.subscriptionType = encodeDays(days);
         this.isActive = isActive;
@@ -104,7 +104,11 @@ public class Subscription extends BaseEntity {
     /**
      * 구독취소하는 메서드
      */
-    public void cancel() {
+    public void updateDisable() {
         this.isActive = false;
+    }
+
+    public void updateEnable() {
+        this.isActive = true;
     }
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/entity/User.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/entity/User.java
@@ -76,10 +76,6 @@ public class User extends BaseEntity {
         this.name = name;
     }
 
-    public void updateActive(boolean isActive) {
-        this.isActive = isActive;
-    }
-
     public void updateDisableUser() {
         this.isActive = false;
     }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
@@ -13,6 +13,7 @@ public enum UserExceptionCode {
     INVALID_ROLE(false, HttpStatus.BAD_REQUEST, "역할 값이 잘못되었습니다."),
     TOKEN_NOT_MATCHED(false, HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰 값이 아닙니다."),
     NOT_FOUND_USER(false, HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_SUBSCRIPTION(false, HttpStatus.NOT_FOUND, "해당 유저에게 구독 정보가 없습니다."),
     INACTIVE_USER(false, HttpStatus.BAD_REQUEST, "이미 삭제된 유저입니다.");
 
     private final boolean isSuccess;

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
@@ -31,8 +31,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     User findBySubscription(Subscription subscription);
 
-    Optional<User> findById(Long id);
-
     default User findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new UserException(UserExceptionCode.NOT_FOUND_USER));
     }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
@@ -7,6 +7,8 @@ import com.example.cs25entity.domain.user.entity.User;
 import com.example.cs25entity.domain.user.exception.UserException;
 import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -31,7 +33,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long id);
 
-    default User findByIdOrElseThrow(Long id){
+    default User findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new UserException(UserExceptionCode.NOT_FOUND_USER));
     }
+
+    Page<User> findAllOrderById(Pageable pageable);
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
@@ -31,9 +31,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     User findBySubscription(Subscription subscription);
 
+    Optional<User> findById(Long id);
+
     default User findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new UserException(UserExceptionCode.NOT_FOUND_USER));
     }
 
-    Page<User> findAllOrderById(Pageable pageable);
+    Page<User> findAllByOrderByIdAsc(Pageable pageable);
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
@@ -36,7 +36,7 @@ public class QuizAdminController {
 
     //GET	관리자 문제  상세 조회	/admin/quizzes/{quizId}
     @GetMapping("/{quizId}")
-    public ApiResponse<QuizDetailDto> getQuizDetails(
+    public ApiResponse<QuizDetailDto> getQuizDetail(
         @Positive @PathVariable(name = "quizId") Long quizId
     ) {
         return new ApiResponse<>(200, quizAdminService.getAdminQuizDetail(quizId));

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAdminController {
 
     private final UserAdminService userAdminService;
-    
+
     //GET	관리자 사용자(회원) 목록 조회	/admin/users
     @GetMapping
     public ApiResponse<Page<UserPageResponseDto>> getUserLists(
@@ -43,7 +43,7 @@ public class UserAdminController {
     }
 
     //DELETE	관리자 사용자(회원) 탈퇴	/admin/users/{userId}
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/{userId}/cancel")
     public ApiResponse<Void> disableUser(
         @Positive @PathVariable(name = "userId") Long userId
     ) {
@@ -53,7 +53,7 @@ public class UserAdminController {
     }
 
     //PATCH	관리자 사용자(회원) 구독 상태 변경	/admin/users/{userId}/subscriptions
-    @PatchMapping("/{userId}")
+    @PatchMapping("/{userId}/subscriptions")
     public ApiResponse<String> updateAdminSubscription(
         @Positive @PathVariable(name = "userId") Long userId,
         @RequestBody @Valid SubscriptionRequestDto request
@@ -63,7 +63,7 @@ public class UserAdminController {
     }
 
     //DELETE	관리자 사용자(회원) 구독 취소 	/admin/users/{userId}/subscriptions
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/{userId}/subscriptions")
     public ApiResponse<Void> cancelSubscription(
         @Positive @PathVariable(name = "userId") Long userId
     ) {

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
@@ -1,0 +1,74 @@
+package com.example.cs25service.domain.admin.controller;
+
+import com.example.cs25common.global.dto.ApiResponse;
+import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
+import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
+import com.example.cs25service.domain.admin.service.UserAdminService;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+public class UserAdminController {
+
+    private final UserAdminService userAdminService;
+    
+    //GET	관리자 사용자(회원) 목록 조회	/admin/users
+    @GetMapping
+    public ApiResponse<Page<UserPageResponseDto>> getUserLists(
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "30") int size
+    ) {
+        return new ApiResponse<>(200, userAdminService.getAdminUsers(page, size));
+    }
+
+    //GET	관리자 사용자(회원) 상세 조회	/admin/users/{userId}
+    @GetMapping("/{userId}")
+    public ApiResponse<UserDetailResponseDto> getUserDetail(
+        @Positive @PathVariable(name = "userId") Long userId
+    ) {
+        return new ApiResponse<>(200, userAdminService.getAdminUserDetail(userId));
+    }
+
+    //DELETE	관리자 사용자(회원) 탈퇴	/admin/users/{userId}
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Void> disableUser(
+        @Positive @PathVariable(name = "userId") Long userId
+    ) {
+        userAdminService.disableUser(userId);
+
+        return new ApiResponse<>(204);
+    }
+
+    //PATCH	관리자 사용자(회원) 구독 상태 변경	/admin/users/{userId}/subscriptions
+    @PatchMapping("/{userId}")
+    public ApiResponse<String> updateAdminSubscription(
+        @Positive @PathVariable(name = "userId") Long userId,
+        @RequestBody @Valid SubscriptionRequestDto request
+    ) {
+        userAdminService.updateSubscription(userId, request);
+        return new ApiResponse<>(200, "구독 정보 수정 성공");
+    }
+
+    //DELETE	관리자 사용자(회원) 구독 취소 	/admin/users/{userId}/subscriptions
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Void> cancelSubscription(
+        @Positive @PathVariable(name = "userId") Long userId
+    ) {
+        userAdminService.cancelSubscription(userId);
+
+        return new ApiResponse<>(204);
+    }
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
@@ -43,7 +43,7 @@ public class UserAdminController {
     }
 
     //DELETE	관리자 사용자(회원) 탈퇴	/admin/users/{userId}
-    @DeleteMapping("/{userId}/cancel")
+    @DeleteMapping("/{userId}")
     public ApiResponse<Void> disableUser(
         @Positive @PathVariable(name = "userId") Long userId
     ) {

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/response/UserDetailResponseDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/response/UserDetailResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.cs25service.domain.admin.dto.response;
+
+import com.example.cs25service.domain.subscription.dto.SubscriptionHistoryDto;
+import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class UserDetailResponseDto {
+
+    private final UserPageResponseDto userInfo;
+
+    private final List<SubscriptionHistoryDto> subscriptionLog;
+
+    private final SubscriptionInfoDto subscriptionInfo;
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/response/UserPageResponseDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/response/UserPageResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.cs25service.domain.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class UserPageResponseDto {
+
+    private final Long userId;
+
+    private final String email;
+
+    private final String name;
+
+    private final String socialType;
+
+    private final boolean isActive;
+
+    private final String role;
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/QuizAdminService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/QuizAdminService.java
@@ -152,6 +152,9 @@ public class QuizAdminService {
     //DELETE	관리자 문제 삭제	/admin/quizzes/{quizId}
     @Transactional
     public void deleteQuiz(@Positive Long quizId) {
+        Quiz quiz = quizRepository.findById(quizId)
+            .orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
 
+        quiz.disableQuiz();
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
@@ -113,6 +113,10 @@ public class UserAdminService {
             throw new UserException(UserExceptionCode.INACTIVE_USER);
         }
 
+        if (user.getSubscription() != null) {
+            user.getSubscription().updateDisable(); //구독도 취소
+        }
+
         user.updateDisableUser();
     }
 
@@ -121,11 +125,19 @@ public class UserAdminService {
         @Valid SubscriptionRequestDto request) {
         User user = userRepository.findByIdOrElseThrow(userId);
 
+        if (user.getSubscription() == null) {
+            throw new UserException(UserExceptionCode.NOT_FOUND_SUBSCRIPTION);
+        }
+
         subscriptionService.updateSubscription(user.getSubscription().getId(), request);
     }
 
     public void cancelSubscription(@Positive Long userId) {
         User user = userRepository.findByIdOrElseThrow(userId);
+
+        if (user.getSubscription() == null) {
+            throw new UserException(UserExceptionCode.NOT_FOUND_SUBSCRIPTION);
+        }
 
         subscriptionService.cancelSubscription(user.getSubscription().getId());
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
@@ -1,0 +1,122 @@
+package com.example.cs25service.domain.admin.service;
+
+import static com.example.cs25entity.domain.subscription.entity.Subscription.decodeDays;
+
+import com.example.cs25entity.domain.subscription.entity.Subscription;
+import com.example.cs25entity.domain.subscription.entity.SubscriptionHistory;
+import com.example.cs25entity.domain.subscription.repository.SubscriptionHistoryRepository;
+import com.example.cs25entity.domain.user.entity.User;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
+import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
+import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
+import com.example.cs25service.domain.subscription.dto.SubscriptionHistoryDto;
+import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
+import com.example.cs25service.domain.subscription.service.SubscriptionService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminService {
+
+    private final UserRepository userRepository;
+    private final SubscriptionService subscriptionService;
+    private final SubscriptionHistoryRepository subscriptionHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public Page<UserPageResponseDto> getAdminUsers(int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<User> userPage = userRepository.findAllOrderById(pageable);
+
+        return userPage.map(user ->
+            UserPageResponseDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .isActive(user.isActive())
+                .name(user.getName())
+                .role(user.getRole().name())
+                .socialType(user.getSocialType().name())
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public UserDetailResponseDto getAdminUserDetail(Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+        UserPageResponseDto userInfo = UserPageResponseDto.builder()
+            .userId(user.getId())
+            .email(user.getEmail())
+            .isActive(user.isActive())
+            .name(user.getName())
+            .role(user.getRole().name())
+            .socialType(user.getSocialType().name())
+            .build();
+
+        Subscription subscription = user.getSubscription();
+        //구독 시작, 구독 종료 날짜 기반으로 구독 기간 계산
+        LocalDate start = subscription.getStartDate();
+        LocalDate end = subscription.getEndDate();
+        long period = ChronoUnit.DAYS.between(start, end);
+
+        SubscriptionInfoDto subscriptionInfo = SubscriptionInfoDto.builder()
+            .category(subscription.getCategory().getCategoryType())
+            .email(subscription.getEmail())
+            .days(decodeDays(subscription.getSubscriptionType()))
+            .active(subscription.isActive())
+            .startDate(subscription.getStartDate())
+            .endDate(subscription.getEndDate())
+            .period(period)
+            .build();
+
+        //로그 다 모아와서 리스트로 만들기
+        List<SubscriptionHistory> subLogs = subscriptionHistoryRepository
+            .findAllBySubscriptionId(subscription.getId());
+        List<SubscriptionHistoryDto> dtoList = subLogs.stream()
+            .map(SubscriptionHistoryDto::fromEntity)
+            .toList();
+
+        return UserDetailResponseDto.builder()
+            .subscriptionInfo(subscriptionInfo)
+            .subscriptionLog(dtoList)
+            .userInfo(userInfo)
+            .build();
+    }
+
+    @Transactional
+    public void disableUser(@Positive Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+        if (!user.isActive()) {
+            throw new UserException(UserExceptionCode.INACTIVE_USER);
+        }
+
+        user.updateDisableUser();
+    }
+
+    @Transactional
+    public void updateSubscription(@Positive Long userId,
+        @Valid SubscriptionRequestDto request) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+        subscriptionService.updateSubscription(user.getSubscription().getId(), request);
+    }
+
+    public void cancelSubscription(@Positive Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+        subscriptionService.cancelSubscription(user.getSubscription().getId());
+    }
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
@@ -85,7 +85,6 @@ public class QuizService {
                         .commentary(dto.getCommentary())
                         .category(subCategory)
                         .level(dto.getLevel())
-                        .isDeleted(true)
                         .build();
                 })
                 .toList();

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
@@ -79,15 +79,16 @@ public class SubscriptionService {
             request.getCategory());
 
         //퀴즈 카테고리가 대분류인지 검증
-        if(!quizCategory.isParentCategory()){
+        if (!quizCategory.isParentCategory()) {
             throw new QuizException(QuizExceptionCode.PARENT_CATEGORY_REQUIRED_ERROR);
         }
 
         // 로그인 한 경우
         if (authUser != null) {
-            User user = userRepository.findUserWithSubscriptionByEmail(authUser.getEmail()).orElseThrow(
-                () -> new UserException(UserExceptionCode.NOT_FOUND_USER)
-            );
+            User user = userRepository.findUserWithSubscriptionByEmail(authUser.getEmail())
+                .orElseThrow(
+                    () -> new UserException(UserExceptionCode.NOT_FOUND_USER)
+                );
 
             // TODO: 로그인을 해도 이메일 체크를 해야할까?
             // this.checkEmail(user.getEmail());
@@ -191,7 +192,7 @@ public class SubscriptionService {
     public void cancelSubscription(Long subscriptionId) {
         Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
 
-        subscription.cancel();
+        subscription.updateDisable();
         createSubscriptionHistory(subscription);
     }
 

--- a/cs25-service/src/test/java/com/example/cs25service/ai/AiServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/ai/AiServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
@@ -51,18 +52,18 @@ class AiServiceTest {
     @BeforeEach
     void setUp() {
         // 카테고리 생성
-        QuizCategory quizCategory = new QuizCategory(null, "BACKEND");
+        QuizCategory quizCategory = new QuizCategory("BACKEND", null);
         em.persist(quizCategory);
 
         // 퀴즈 생성
         quiz = new Quiz(
-            null,
             QuizFormatType.SUBJECTIVE,
             "HTTP와 HTTPS의 차이점을 설명하세요.",
             "HTTPS는 암호화, HTTP는 암호화X",
             "HTTPS는 SSL/TLS로 암호화되어 보안성이 높다.",
             null,
-            quizCategory
+            quizCategory,
+            QuizLevel.EASY
         );
         quizRepository.save(quiz);
 


### PR DESCRIPTION

## 🔎 작업 내용

- 유저 목록불러오기, 유저 상세정보보기, 유저의 구독정보 수정하기

---

## 🛠️ 변경 사항

- ai 테스트 코드쪽에 엔티티 수정한거에 맞게 변경안되어있어서 바꿧음.
---

## 🧩 트러블 슈팅

- 관리자가 유저의 구독 내용은바꿀 수 잇는데, 비로그인 사용자의 구독내용 바꾸는 게 없어서 추가해야할듯

---

## 🧯 해결해야 할 문제

- 겹치는 로직은 서비스 호출로 구현
---

## 📌 참고 사항

- 결과값들은 api 명세서에 적어놧음.
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인
