### PR TITLE
Refactor/140 : Admin 권한이 필요한 api에 대한 권한 검증 로직 추가, 유저의 카테고리별 정답률 api 위치 리팩토링

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/jobs/DailyMailSendJob.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/jobs/DailyMailSendJob.java
@@ -5,6 +5,7 @@ import com.example.cs25batch.batch.dto.MailDto;
 import com.example.cs25batch.batch.service.BatchMailService;
 import com.example.cs25batch.batch.service.BatchSubscriptionService;
 import com.example.cs25batch.batch.service.TodayQuizService;
+import com.example.cs25batch.config.ThreadShuttingJobListener;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.subscription.dto.SubscriptionMailTargetDto;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
@@ -14,6 +15,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
@@ -145,7 +147,7 @@ public class DailyMailSendJob {
     }
 
     @Bean
-    public TaskExecutor taskExecutor() {
+    public ThreadPoolTaskExecutor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(10);
@@ -183,9 +185,12 @@ public class DailyMailSendJob {
 
     @Bean
     public Job mailConsumerWithAsyncJob(JobRepository jobRepository,
-        @Qualifier("mailConsumerWithAsyncStep") Step mailConsumeStep) {
+        @Qualifier("mailConsumerWithAsyncStep") Step mailConsumeStep,
+        ThreadShuttingJobListener threadShuttingJobListener
+    ) {
         return new JobBuilder("mailConsumerWithAsyncJob", jobRepository)
             .start(mailConsumeStep)
+            .listener(threadShuttingJobListener)
             .build();
     }
 

--- a/cs25-batch/src/main/java/com/example/cs25batch/config/ThreadShuttingJobListener.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/config/ThreadShuttingJobListener.java
@@ -1,0 +1,22 @@
+package com.example.cs25batch.config;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadShuttingJobListener implements JobExecutionListener {
+
+    private final ThreadPoolTaskExecutor taskExecutor;
+
+    public ThreadShuttingJobListener(@Qualifier("taskExecutor") ThreadPoolTaskExecutor taskExecutor) {
+        this.taskExecutor = taskExecutor;
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        taskExecutor.shutdown();
+    }
+}

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/QuizCategory.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/entity/QuizCategory.java
@@ -34,7 +34,7 @@ public class QuizCategory extends BaseEntity {
     private QuizCategory parent;
 
     //소분류
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<QuizCategory> children = new ArrayList<>();
 
     @Builder

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
@@ -11,6 +11,7 @@ public enum UserExceptionCode {
     EVENT_CRUD_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 값을 레디스에 읽기/저장 실패했으요"),
     LOCK_FAILED(false, HttpStatus.CONFLICT, "요청 시간 초과, 락 획득 실패"),
     INVALID_ROLE(false, HttpStatus.BAD_REQUEST, "역할 값이 잘못되었습니다."),
+    UNAUTHORIZE_ROLE(false, HttpStatus.FORBIDDEN, "권한이 없습니다."),
     TOKEN_NOT_MATCHED(false, HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰 값이 아닙니다."),
     NOT_FOUND_USER(false, HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_SUBSCRIPTION(false, HttpStatus.NOT_FOUND, "해당 유저에게 구독 정보가 없습니다."),

--- a/cs25-service/src/main/java/com/example/cs25service/domain/crawler/controller/CrawlerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/crawler/controller/CrawlerController.java
@@ -3,8 +3,10 @@ package com.example.cs25service.domain.crawler.controller;
 import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.crawler.dto.CreateDocumentRequest;
 import com.example.cs25service.domain.crawler.service.CrawlerService;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,10 +19,11 @@ public class CrawlerController {
 
     @PostMapping("/crawlers/github")
     public ApiResponse<String> crawlingGithub(
-        @Valid @RequestBody CreateDocumentRequest request
+        @Valid @RequestBody CreateDocumentRequest request,
+        @AuthenticationPrincipal AuthUser authUser
     ) {
         try {
-            crawlerService.crawlingGithubDocument(request.getLink());
+            crawlerService.crawlingGithubDocument(authUser, request.getLink());
             return new ApiResponse<>(200, request.getLink() + " 크롤링 성공");
         } catch (IllegalArgumentException e) {
             return new ApiResponse<>(400, "잘못된 GitHub URL: " + e.getMessage());

--- a/cs25-service/src/main/java/com/example/cs25service/domain/crawler/service/CrawlerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/crawler/service/CrawlerService.java
@@ -1,5 +1,8 @@
 package com.example.cs25service.domain.crawler.service;
 
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.ai.service.RagService;
 import com.example.cs25service.domain.crawler.github.GitHubRepoInfo;
 import com.example.cs25service.domain.crawler.github.GitHubUrlParser;
@@ -14,6 +17,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.example.cs25service.domain.security.dto.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.document.Document;
 import org.springframework.core.ParameterizedTypeReference;
@@ -33,7 +38,12 @@ public class CrawlerService {
     private final RestTemplate restTemplate;
     private String githubToken;
 
-    public void crawlingGithubDocument(String url) {
+    public void crawlingGithubDocument(AuthUser authUser, String url) {
+
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
+
         //url 에서 필요 정보 추출
         GitHubRepoInfo repoInfo = GitHubUrlParser.parseGitHubUrl(url);
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/mail/controller/MailLogController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/mail/controller/MailLogController.java
@@ -5,11 +5,15 @@ import com.example.cs25entity.domain.mail.dto.MailLogSearchDto;
 import com.example.cs25service.domain.mail.dto.MailLogResponse;
 import com.example.cs25service.domain.mail.service.MailLogService;
 import java.util.List;
+
+import com.example.cs25service.domain.security.dto.AuthUser;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,21 +28,30 @@ public class MailLogController {
     private final MailLogService mailLogService;
 
     @GetMapping
-    public Page<MailLogResponse> getMailLogs(
+    public ApiResponse<Page<MailLogResponse>> getMailLogs(
         @RequestBody MailLogSearchDto condition,
-        @PageableDefault(size = 20, sort = "sendDate", direction = Direction.DESC) Pageable pageable
+        @PageableDefault(size = 20, sort = "sendDate", direction = Direction.DESC) Pageable pageable,
+        @AuthenticationPrincipal AuthUser authUser
     ) {
-        return mailLogService.getMailLogs(condition, pageable);
+        Page<MailLogResponse> results =  mailLogService.getMailLogs(authUser, condition, pageable);
+        return new ApiResponse<>(200, results);
     }
 
-    @GetMapping("/{id}")
-    public MailLogResponse getMailLog(@PathVariable Long id) {
-        return mailLogService.getMailLog(id);
+    @GetMapping("/{mailLogId}")
+    public ApiResponse<MailLogResponse> getMailLog(
+            @PathVariable @NonNull Long mailLogId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        MailLogResponse result =  mailLogService.getMailLog(authUser, mailLogId);
+        return new ApiResponse<>(200, result);
     }
 
     @DeleteMapping
-    public ApiResponse<String> deleteMailLogs(@RequestBody List<Long> ids) {
-        mailLogService.deleteMailLogs(ids);
+    public ApiResponse<String> deleteMailLogs(
+            @RequestBody List<Long> mailLogids,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        mailLogService.deleteMailLogs(authUser, mailLogids);
         return new ApiResponse<>(200, "MailLog 삭제 완료");
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/mail/service/MailLogService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/mail/service/MailLogService.java
@@ -3,8 +3,13 @@ package com.example.cs25service.domain.mail.service;
 import com.example.cs25entity.domain.mail.dto.MailLogSearchDto;
 import com.example.cs25entity.domain.mail.entity.MailLog;
 import com.example.cs25entity.domain.mail.repository.MailLogRepository;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.mail.dto.MailLogResponse;
 import java.util.List;
+
+import com.example.cs25service.domain.security.dto.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +24,12 @@ public class MailLogService {
 
     //전체 로그 페이징 조회
     @Transactional(readOnly = true)
-    public Page<MailLogResponse> getMailLogs(MailLogSearchDto condition, Pageable pageable) {
+    public Page<MailLogResponse> getMailLogs(AuthUser authUser, MailLogSearchDto condition, Pageable pageable) {
+
+        //유저 권한 확인
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
 
         //시작일과 종료일 모두 설정했을 때
         if (condition.getStartDate() != null && condition.getEndDate() != null) {
@@ -34,13 +44,22 @@ public class MailLogService {
 
     //단일 로그 조회
     @Transactional(readOnly = true)
-    public MailLogResponse getMailLog(Long id) {
+    public MailLogResponse getMailLog(AuthUser authUser, Long id) {
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
+
         MailLog mailLog = mailLogRepository.findByIdOrElseThrow(id);
         return MailLogResponse.from(mailLog);
     }
 
     @Transactional
-    public void deleteMailLogs(List<Long> ids) {
+    public void deleteMailLogs(AuthUser authUser, List<Long> ids) {
+
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
+
         if (ids == null || ids.isEmpty()) {
             throw new IllegalArgumentException("삭제할 로그 데이터가 없습니다.");
         }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
@@ -39,11 +39,11 @@ public class ProfileController {
         return new ApiResponse<>(200, profileService.getWrongQuiz(authUser));
     }
 
-    @GetMapping("/{userId}/correct-rate")
+    @GetMapping("/correct-rate")
     public ApiResponse<CategoryUserAnswerRateResponse> getCorrectRateByCategory(
-            @PathVariable Long userId
+            @AuthenticationPrincipal AuthUser authUser
     ){
-        return new ApiResponse<>(200, profileService.getUserQuizAnswerCorrectRate(userId));
+        return new ApiResponse<>(200, profileService.getUserQuizAnswerCorrectRate(authUser));
     }
 }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
@@ -6,9 +6,11 @@ import com.example.cs25service.domain.profile.dto.ProfileWrongQuizResponseDto;
 import com.example.cs25service.domain.profile.dto.UserSubscriptionResponseDto;
 import com.example.cs25service.domain.profile.service.ProfileService;
 import com.example.cs25service.domain.security.dto.AuthUser;
+import com.example.cs25service.domain.userQuizAnswer.dto.CategoryUserAnswerRateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,6 +37,13 @@ public class ProfileController {
     public ApiResponse<ProfileWrongQuizResponseDto> getWrongQuiz(@AuthenticationPrincipal AuthUser authUser){
 
         return new ApiResponse<>(200, profileService.getWrongQuiz(authUser));
+    }
+
+    @GetMapping("/{userId}/correct-rate")
+    public ApiResponse<CategoryUserAnswerRateResponse> getCorrectRateByCategory(
+            @PathVariable Long userId
+    ){
+        return new ApiResponse<>(200, profileService.getUserQuizAnswerCorrectRate(userId));
     }
 }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
@@ -99,6 +99,7 @@ public class ProfileService {
         );
     }
 
+    //유저의 소분류 카테고리별 정답률 조회
     public CategoryUserAnswerRateResponse getUserQuizAnswerCorrectRate(Long userId){
         //유저 검증
         User user = userRepository.findByIdOrElseThrow(userId);
@@ -109,7 +110,7 @@ public class ProfileService {
         //유저 Id에 따른 구독 정보의 대분류 카테고리 조회
         QuizCategory parentCategory = quizCategoryRepository.findQuizCategoryByUserId(userId);
 
-        //소분류 조회
+        //소분류 조회 -> getChildren()에서 실제 childCategories를 조회해오기 때문에 아래에서 이를 사용할 때 N+1 문제가 발생하지 않음
         List<QuizCategory> childCategories = parentCategory.getChildren();
 
         Map<String, Double> rates = new HashMap<>();

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
@@ -1,11 +1,14 @@
 package com.example.cs25service.domain.profile.service;
 
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.subscription.entity.SubscriptionHistory;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionHistoryRepository;
 import com.example.cs25entity.domain.user.entity.User;
 import com.example.cs25entity.domain.user.exception.UserException;
 import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.profile.dto.ProfileResponseDto;
 import com.example.cs25service.domain.profile.dto.ProfileWrongQuizResponseDto;
@@ -15,10 +18,13 @@ import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.subscription.dto.SubscriptionHistoryDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
 import com.example.cs25service.domain.subscription.service.SubscriptionService;
+import com.example.cs25service.domain.userQuizAnswer.dto.CategoryUserAnswerRateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,6 +35,7 @@ public class ProfileService {
     private final UserRepository userRepository;
     private final SubscriptionService subscriptionService;
     private final SubscriptionHistoryRepository subscriptionHistoryRepository;
+    private final QuizCategoryRepository quizCategoryRepository;
 
     // 구독 정보 가져오기
     public UserSubscriptionResponseDto getUserSubscription(AuthUser authUser) {
@@ -90,5 +97,43 @@ public class ProfileService {
                 user.getScore(),
                 myRank
         );
+    }
+
+    public CategoryUserAnswerRateResponse getUserQuizAnswerCorrectRate(Long userId){
+        //유저 검증
+        User user = userRepository.findByIdOrElseThrow(userId);
+        if(!user.isActive()){
+            throw new UserException(UserExceptionCode.INACTIVE_USER);
+        }
+
+        //유저 Id에 따른 구독 정보의 대분류 카테고리 조회
+        QuizCategory parentCategory = quizCategoryRepository.findQuizCategoryByUserId(userId);
+
+        //소분류 조회
+        List<QuizCategory> childCategories = parentCategory.getChildren();
+
+        Map<String, Double> rates = new HashMap<>();
+        //유저가 푼 문제들 중, 소분류에 속하는 로그 다 가져와
+        for(QuizCategory child : childCategories){
+            List<UserQuizAnswer> answers = userQuizAnswerRepository.findByUserIdAndQuizCategoryId(userId, child.getId());
+
+            if (answers.isEmpty()) {
+                rates.put(child.getCategoryType(), 0.0);
+                continue;
+            }
+
+            long totalAnswers = answers.size();
+            long correctAnswers = answers.stream()
+                    .filter(UserQuizAnswer::getIsCorrect) // 정답인 경우 필터링
+                    .count();
+
+            double answerRate = (double) correctAnswers / totalAnswers * 100;
+            rates.put(child.getCategoryType(), answerRate);
+
+        }
+
+        return CategoryUserAnswerRateResponse.builder()
+                .correctRates(rates)
+                .build();
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
@@ -100,7 +100,10 @@ public class ProfileService {
     }
 
     //유저의 소분류 카테고리별 정답률 조회
-    public CategoryUserAnswerRateResponse getUserQuizAnswerCorrectRate(Long userId){
+    public CategoryUserAnswerRateResponse getUserQuizAnswerCorrectRate(AuthUser authUser){
+
+        Long userId = authUser.getId();
+
         //유저 검증
         User user = userRepository.findByIdOrElseThrow(userId);
         if(!user.isActive()){

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizCategoryController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizCategoryController.java
@@ -3,9 +3,11 @@ package com.example.cs25service.domain.quiz.controller;
 import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.quiz.dto.CreateQuizCategoryDto;
 import com.example.cs25service.domain.quiz.service.QuizCategoryService;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,9 +27,10 @@ public class QuizCategoryController {
 
     @PostMapping("/quiz-categories")
     public ApiResponse<String> createQuizCategory(
-        @Valid @RequestBody CreateQuizCategoryDto request
+        @Valid @RequestBody CreateQuizCategoryDto request,
+        @AuthenticationPrincipal AuthUser authUser
     ) {
-        quizCategoryService.createQuizCategory(request);
+        quizCategoryService.createQuizCategory(authUser, request);
         return new ApiResponse<>(200, "카테고리 등록 성공");
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizController.java
@@ -4,8 +4,10 @@ import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
 import com.example.cs25service.domain.quiz.dto.QuizResponseDto;
 import com.example.cs25service.domain.quiz.service.QuizService;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +27,8 @@ public class QuizController {
     public ApiResponse<String> uploadQuizByJsonFile(
         @RequestParam("file") MultipartFile file,
         @RequestParam("categoryType") String categoryType,
-        @RequestParam("formatType") QuizFormatType formatType
+        @RequestParam("formatType") QuizFormatType formatType,
+        @AuthenticationPrincipal AuthUser authUser
     ) {
         if (file.isEmpty()) {
             return new ApiResponse<>(400, "파일이 비어있습니다.");
@@ -36,7 +39,7 @@ public class QuizController {
             return new ApiResponse<>(400, "JSON 파일만 업로드 가능합니다.");
         }
 
-        quizService.uploadQuizJson(file, categoryType, formatType);
+        quizService.uploadQuizJson(authUser, file, categoryType, formatType);
         return new ApiResponse<>(200, "문제 등록 성공");
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizCategoryService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizCategoryService.java
@@ -5,8 +5,13 @@ import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.quiz.dto.CreateQuizCategoryDto;
 import java.util.List;
+
+import com.example.cs25service.domain.security.dto.AuthUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +25,12 @@ public class QuizCategoryService {
     private final QuizCategoryRepository quizCategoryRepository;
 
     @Transactional
-    public void createQuizCategory(CreateQuizCategoryDto request) {
+    public void createQuizCategory(AuthUser authUser, CreateQuizCategoryDto request) {
+
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
+
         quizCategoryRepository.findByCategoryType(request.getCategory())
             .ifPresent(c -> {
                 throw new QuizException(QuizExceptionCode.QUIZ_CATEGORY_ALREADY_EXISTS_ERROR);

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
@@ -7,8 +7,12 @@ import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.quiz.dto.CreateQuizDto;
 import com.example.cs25service.domain.quiz.dto.QuizResponseDto;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -37,8 +41,17 @@ public class QuizService {
     private final QuizCategoryRepository quizCategoryRepository;
 
     @Transactional
-    public void uploadQuizJson(MultipartFile file, String categoryType,
-        QuizFormatType formatType) {
+    public void uploadQuizJson(
+            AuthUser authUser,
+            MultipartFile file,
+            String categoryType,
+            QuizFormatType formatType
+    ) {
+
+        if(authUser.getRole() != Role.ADMIN){
+            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        }
+
         try {
             //대분류 확인
             QuizCategory category = quizCategoryRepository.findByCategoryType(categoryType)

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -34,10 +34,4 @@ public class UserQuizAnswerController {
         return new ApiResponse<>(200, userQuizAnswerService.getSelectionRateByOption(quizId));
     }
 
-    @GetMapping("/{userId}/correct-rate")
-    public ApiResponse<CategoryUserAnswerRateResponse> getCorrectRateByCategory(
-        @PathVariable Long userId
-    ){
-        return new ApiResponse<>(200, userQuizAnswerService.getUserQuizAnswerCorrectRate(userId));
-    }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
@@ -108,41 +108,4 @@ public class UserQuizAnswerService {
         return new SelectionRateResponseDto(rates, total);
     }
 
-    public CategoryUserAnswerRateResponse getUserQuizAnswerCorrectRate(Long userId){
-        //유저 검증
-        User user = userRepository.findByIdOrElseThrow(userId);
-        if(!user.isActive()){
-            throw new UserException(UserExceptionCode.INACTIVE_USER);
-        }
-
-        //유저 Id에 따른 구독 정보의 대분류 카테고리 조회
-        QuizCategory parentCategory = quizCategoryRepository.findQuizCategoryByUserId(userId);
-
-        //소분류 조회
-        List<QuizCategory> childCategories = parentCategory.getChildren();
-
-        Map<String, Double> rates = new HashMap<>();
-        //유저가 푼 문제들 중, 소분류에 속하는 로그 다 가져와
-        for(QuizCategory child : childCategories){
-            List<UserQuizAnswer> answers = userQuizAnswerRepository.findByUserIdAndQuizCategoryId(userId, child.getId());
-
-            if (answers.isEmpty()) {
-                rates.put(child.getCategoryType(), 0.0);
-                continue;
-            }
-
-            long totalAnswers = answers.size();
-            long correctAnswers = answers.stream()
-                .filter(UserQuizAnswer::getIsCorrect) // 정답인 경우 필터링
-                .count();
-
-            double answerRate = (double) correctAnswers / totalAnswers * 100;
-            rates.put(child.getCategoryType(), answerRate);
-
-        }
-
-        return CategoryUserAnswerRateResponse.builder()
-            .correctRates(rates)
-            .build();
-    }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 메일 로그 CRUD 에서 ADMIN 권한 검증
- 퀴즈 카테고리, 퀴즈 생성 및 업로드, 크롤링 Create에서 ADMIN 권한 검증 추가 
- 유저의 카테고리별 정답률 api를 profile 패키지 내부로 리팩토링

close #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 프로필에서 사용자의 퀴즈 카테고리별 정답률을 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.

- **버그 수정**
    - API 응답이 일관된 포맷(`ApiResponse`)으로 표준화되어 반환됩니다.

- **기능 개선**
    - 퀴즈 업로드, 카테고리 생성, 크롤러, 메일 로그 등 주요 관리자 기능에 관리자 권한 검증이 추가되어, 관리자가 아닌 사용자는 접근이 제한됩니다.
    - 메일 로그 관련 API에 사용자 인증 정보가 반영되었습니다.
    - 배치 작업 종료 시 스레드 풀이 정상적으로 종료되도록 개선되었습니다.

- **기능 변경**
    - 기존에 사용자별 퀴즈 정답률을 제공하던 엔드포인트가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->