### PR TITLE
Feat/124

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCategoryRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCategoryRepository.java
@@ -45,4 +45,5 @@ public interface QuizCategoryRepository extends JpaRepository<QuizCategory, Long
         "WHERE u.id = :userId")
     QuizCategory findQuizCategoryByUserId(@Param("userId") Long userId);
 
+    boolean existsByCategoryType(String categoryType);
 }

--- a/cs25-service/build.gradle
+++ b/cs25-service/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     // ai
     implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0'
     implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma:1.0.0'
-
+    implementation "org.springframework.ai:spring-ai-starter-model-anthropic:1.0.0"
     testImplementation 'org.springframework.security:spring-security-test'
 
     // Jwt

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
@@ -1,0 +1,10 @@
+package com.example.cs25service.domain.ai.client;
+
+import org.springframework.ai.chat.client.ChatClient;
+
+public interface AiChatClient {
+
+    String call(String systemPrompt, String userPrompt);
+
+    ChatClient raw(); // Optional: low-level access if needed
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
@@ -6,5 +6,5 @@ public interface AiChatClient {
 
     String call(String systemPrompt, String userPrompt);
 
-    ChatClient raw(); // Optional: low-level access if needed
+    ChatClient raw();
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
@@ -1,0 +1,26 @@
+package com.example.cs25service.domain.ai.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClaudeChatClient implements AiChatClient {
+
+    private final ChatClient anthropicChatClient;
+
+    @Override
+    public String call(String systemPrompt, String userPrompt) {
+        return anthropicChatClient.prompt()
+            .system(systemPrompt)
+            .user(userPrompt)
+            .call()
+            .content();
+    }
+
+    @Override
+    public ChatClient raw() {
+        return anthropicChatClient;
+    }
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
@@ -1,0 +1,30 @@
+package com.example.cs25service.domain.ai.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FallbackAiChatClient implements AiChatClient {
+
+    private final OpenAiChatClient openAiClient;
+    private final ClaudeChatClient claudeClient;
+
+    @Override
+    public String call(String systemPrompt, String userPrompt) {
+        try {
+            return openAiClient.call(systemPrompt, userPrompt);
+        } catch (Exception e) {
+            log.warn("OpenAI 호출 실패. Claude로 폴백합니다.", e);
+            return claudeClient.call(systemPrompt, userPrompt);
+        }
+    }
+
+    @Override
+    public org.springframework.ai.chat.client.ChatClient raw() {
+        return openAiClient.raw(); // 기본은 OpenAI 기준
+    }
+}
+

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
@@ -2,11 +2,13 @@ package com.example.cs25service.domain.ai.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-@Component
+@Component("fallbackAiChatClient")
 @RequiredArgsConstructor
 @Slf4j
+@Primary
 public class FallbackAiChatClient implements AiChatClient {
 
     private final OpenAiChatClient openAiClient;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
@@ -1,5 +1,7 @@
 package com.example.cs25service.domain.ai.client;
 
+import com.example.cs25service.domain.ai.exception.AiException;
+import com.example.cs25service.domain.ai.exception.AiExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Component;
@@ -12,11 +14,16 @@ public class OpenAiChatClient implements AiChatClient {
 
     @Override
     public String call(String systemPrompt, String userPrompt) {
-        return openAiChatClient.prompt()
-            .system(systemPrompt)
-            .user(userPrompt)
-            .call()
-            .content();
+        try {
+            return openAiChatClient.prompt()
+                .system(systemPrompt)
+                .user(userPrompt)
+                .call()
+                .content()
+                .trim();
+        } catch (Exception e) {
+            throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @Override

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
@@ -1,0 +1,27 @@
+package com.example.cs25service.domain.ai.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiChatClient implements AiChatClient {
+
+    private final ChatClient openAiChatClient;
+
+    @Override
+    public String call(String systemPrompt, String userPrompt) {
+        return openAiChatClient.prompt()
+            .system(systemPrompt)
+            .user(userPrompt)
+            .call()
+            .content();
+    }
+
+    @Override
+    public ChatClient raw() {
+        return openAiChatClient;
+    }
+}
+

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/config/AiConfig.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/config/AiConfig.java
@@ -1,5 +1,7 @@
-package com.example.cs25service.config;
+package com.example.cs25service.domain.ai.config;
 
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.api.AnthropicApi;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -16,8 +18,30 @@ public class AiConfig {
     private String openAiKey;
 
     @Bean
-    public ChatClient chatClient(OpenAiChatModel chatModel) {
+    public ChatClient AichatClient(OpenAiChatModel chatModel) {
         return ChatClient.create(chatModel);
+    }
+
+    @Bean
+    public OpenAiChatModel openAiChatModel() {
+        OpenAiApi api = OpenAiApi.builder()
+            .apiKey(openAiKey)
+            .build();
+
+        return OpenAiChatModel.builder()
+            .openAiApi(api)
+            .build();
+    }
+
+    @Bean
+    public AnthropicChatModel anthropicChatModel(@Value("${spring.ai.anthropic.api-key}") String claudeKey) {
+        AnthropicApi api = AnthropicApi.builder()
+            .apiKey(claudeKey)
+            .build();
+
+        return AnthropicChatModel.builder()
+            .anthropicApi(api)
+            .build();
     }
 
     @Bean

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
@@ -4,19 +4,23 @@ package com.example.cs25service.domain.ai.service;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
+import com.example.cs25service.domain.ai.client.AiChatClient;
 import com.example.cs25service.domain.ai.dto.response.AiFeedbackResponse;
 import com.example.cs25service.domain.ai.exception.AiException;
 import com.example.cs25service.domain.ai.exception.AiExceptionCode;
 import com.example.cs25service.domain.ai.prompt.AiPromptProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AiService {
 
-    private final ChatClient chatClient;
+    @Qualifier("fallbackAiChatClient")
+    private final AiChatClient aiChatClient;
+
     private final QuizRepository quizRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final UserQuizAnswerRepository userQuizAnswerRepository;
@@ -33,18 +37,7 @@ public class AiService {
         String userPrompt = promptProvider.getFeedbackUser(quiz, answer, docs);
         String systemPrompt = promptProvider.getFeedbackSystem();
 
-        String feedback;
-        try {
-            feedback = chatClient.prompt()
-                .system(systemPrompt)
-                .user(userPrompt)
-                .call()
-                .content()
-                .trim();
-        } catch (Exception e) {
-            throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
-        }
-
+        String feedback = aiChatClient.call(systemPrompt, userPrompt);
         boolean isCorrect = feedback.startsWith("정답");
 
         answer.updateIsCorrect(isCorrect);

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -51,11 +51,14 @@ spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
 spring.security.oauth2.client.provider.naver.user-name-attribute=response
-#AI
+#OPEN AI
 spring.ai.openai.api-key=${OPENAI_API_KEY}
 spring.ai.openai.base-url=https://api.openai.com
 spring.ai.openai.chat.options.model=gpt-4o
 spring.ai.openai.chat.options.temperature=0.7
+# Claude
+spring.ai.anthropic.api-key=${CLAUDE_API_KEY}
+spring.ai.anthropic.chat.options.model=claude-3-opus-20240229
 #MAIL
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/cs25-service/src/test/java/com/example/cs25service/ai/AiQuestionGeneratorServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/ai/AiQuestionGeneratorServiceTest.java
@@ -41,16 +41,25 @@ class AiQuestionGeneratorServiceTest {
 
     @BeforeEach
     void setUp() {
-        // 벡터 검색에 사용되는 카테고리 목록 등록
-        quizCategoryRepository.saveAll(List.of(
-            new QuizCategory(null, "운영체제"),
-            new QuizCategory(null, "컴퓨터구조"),
-            new QuizCategory(null, "자료구조"),
-            new QuizCategory(null, "네트워크"),
-            new QuizCategory(null, "DB"),
-            new QuizCategory(null, "보안")
-        ));
+        List<String> requiredCategories = List.of(
+            "SoftwareDevelopment",
+            "SoftwareDesign",
+            "Programming",
+            "Database",
+            "InformationSystemManagement"
+        );
+
+        for (String categoryType : requiredCategories) {
+            boolean exists = quizCategoryRepository.existsByCategoryType(categoryType);
+            if (!exists) {
+                quizCategoryRepository.save(new QuizCategory(categoryType, null));
+            }
+        }
+
+        em.flush();
+        em.clear();
     }
+
 
     @Test
     @DisplayName("RAG 문서를 기반으로 문제를 생성하고 DB에 저장한다")

--- a/cs25-service/src/test/java/com/example/cs25service/ai/FallbackAiChatClientIntegrationTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/ai/FallbackAiChatClientIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.example.cs25service.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
+import com.example.cs25entity.domain.subscription.entity.Subscription;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.entity.SocialType;
+import com.example.cs25entity.domain.user.entity.User;
+import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
+import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
+import com.example.cs25service.domain.ai.service.AiService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class FallbackAiChatClientIntegrationTest {
+
+    @Autowired
+    private AiService aiService;
+
+    @Autowired
+    private UserQuizAnswerRepository userQuizAnswerRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("OpenAI 호출 실패 시 Claude로 폴백하여 피드백 생성한다")
+    void openAiFail_thenUseClaudeFeedback() {
+        // given - 기본 퀴즈, 사용자, 정답 생성
+        QuizCategory category = QuizCategory.builder()
+            .categoryType("네트워크")
+            .parent(null)
+            .build();
+        em.persist(category);
+
+        Quiz quiz = Quiz.builder()
+            .type(QuizFormatType.SUBJECTIVE)
+            .question("HTTP와 HTTPS의 차이를 설명하시오.")
+            .answer("HTTPS는 보안이 강화된 프로토콜이다.")
+            .commentary("HTTPS는 SSL/TLS를 통해 데이터 암호화를 제공한다.")
+            .category(category)
+            .level(QuizLevel.NORMAL)
+            .build();
+        em.persist(quiz);
+
+        Subscription subscription = Subscription.builder()
+            .category(category)
+            .email("fallback@test.com")
+            .startDate(LocalDate.now().minusDays(1))
+            .endDate(LocalDate.now().plusDays(30))
+            .subscriptionType(Set.of())
+            .build();
+        em.persist(subscription);
+
+        User user = User.builder()
+            .email("fallback@test.com")
+            .name("fallback_user")
+            .socialType(SocialType.KAKAO)
+            .role(Role.USER)
+            .subscription(subscription)
+            .build();
+        em.persist(user);
+
+        UserQuizAnswer answer = UserQuizAnswer.builder()
+            .user(user)
+            .quiz(quiz)
+            .userAnswer("HTTPS는 HTTP보다 빠르다.")
+            .aiFeedback(null)
+            .isCorrect(null)
+            .subscription(subscription)
+            .build();
+        em.persist(answer);
+
+        // when - AI 피드백 호출
+        var response = aiService.getFeedback(answer.getId());
+
+        // then - Claude로부터 받은 피드백이 저장됨
+        UserQuizAnswer updated = userQuizAnswerRepository.findById(answer.getId()).orElseThrow();
+
+        assertThat(updated.getAiFeedback()).isNotBlank();
+        assertThat(updated.getIsCorrect()).isNotNull();
+        System.out.println("📢 Claude 기반 피드백: " + updated.getAiFeedback());
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/ai/FallbackAiChatClientTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/ai/FallbackAiChatClientTest.java
@@ -1,0 +1,37 @@
+package com.example.cs25service.ai;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.example.cs25service.domain.ai.client.ClaudeChatClient;
+import com.example.cs25service.domain.ai.client.FallbackAiChatClient;
+import com.example.cs25service.domain.ai.client.OpenAiChatClient;
+import org.junit.jupiter.api.Test;
+
+public class FallbackAiChatClientTest {
+
+    @Test
+    void openAiFail_thenFallbackToClaude() {
+        // given
+        OpenAiChatClient openAiMock = mock(OpenAiChatClient.class);
+        ClaudeChatClient claudeMock = mock(ClaudeChatClient.class);
+
+        // OpenAI는 실패하도록 설정
+        when(openAiMock.call(anyString(), anyString()))
+            .thenThrow(new RuntimeException("OpenAI failure"));
+
+        // Claude는 정상 반환
+        when(claudeMock.call(anyString(), anyString()))
+            .thenReturn("Claude 응답입니다.");
+
+        FallbackAiChatClient fallbackClient = new FallbackAiChatClient(openAiMock, claudeMock);
+
+        // when
+        String result = fallbackClient.call("시스템 프롬프트", "유저 프롬프트");
+
+        // then
+        assertThat(result).isEqualTo("Claude 응답입니다.");
+        verify(openAiMock, times(1)).call(anyString(), anyString());
+        verify(claudeMock, times(1)).call(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- OpenAI 호출 실패 시 Claude 모델을 통해 Fallback하여 AI 응답을 생성하는 구조를 도입
- AI 피드백 생성 흐름을 `FallbackAiChatClient` 중심으로 재구성

---

## 🛠️ 변경 사항

- `AiChatClient` 인터페이스 도입 및 추상화
- `OpenAiChatClient` 및 `ClaudeChatClient` 각각 구현체로 분리
- `FallbackAiChatClient` 구현
    - OpenAI 실패 시 Claude로 폴백
    - `@Primary` 지정으로 기본 `AiChatClient`로 사용됨
- `AiService`에서 기존 `ChatClient` 대신 `AiChatClient` 의존성 주입
- `AiConfig`에서 OpenAI / Claude 모델 및 ChatClient 빈 설정 분리
- 통합 테스트(`FallbackAiChatClientIntegrationTest`) 작성
    - 실제 DB 연동 테스트로 폴백 로직 확인
- 단위 테스트(`FallbackAiChatClientTest`) 작성
    - Mock 기반 테스트로 폴백 흐름 검증

---

## 🧩 트러블 슈팅

- 문제: ChatClient가 두 개 빈으로 등록되며 충돌 발생
    - `ClaudeChatClient`, `OpenAiChatClient` 모두 `ChatClient` 빈을 가짐
- 해결 : @Primary 어노테이션 사용으로 FallbackAiChatCleint 우선으로 빈 등록되게 변경