### PR TITLE
Feat/150 오늘의 문제뽑기 알고리즘 변경

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/controller/QuizTestController.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/controller/QuizTestController.java
@@ -20,10 +20,10 @@ public class QuizTestController {
         return new ApiResponse<>(200, accuracyService.getTodayQuiz(1L));
     }
 
-    @GetMapping("/accuracyTest/getTodayQuizNew")
-    public ApiResponse<QuizDto> getTodayQuizNew() {
-        return new ApiResponse<>(200, accuracyService.getTodayQuizNew(1L));
-    }
+//    @GetMapping("/accuracyTest/getTodayQuizNew")
+//    public ApiResponse<QuizDto> getTodayQuizNew() {
+//        return new ApiResponse<>(200, accuracyService.getTodayQuizNew(1L));
+//    }
 
     @PostMapping("/emails/getTodayQuiz")
     public ApiResponse<String> sendTodayQuiz(

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
@@ -99,9 +99,9 @@ public class TodayQuizService {
     //유저 정답률 기준으로 바운더리 정해줌
     private List<QuizLevel> getAllowedDifficulties(double accuracy) {
         // 난이도 낮
-        if (accuracy <= 0.5) {
+        if (accuracy <= 50.0) {
             return List.of(QuizLevel.EASY);
-        } else if (accuracy <= 0.75) { //난이도 중
+        } else if (accuracy <= 75.0) { //난이도 중
             return List.of(QuizLevel.EASY, QuizLevel.NORMAL);
         } else { //난이도 상
             return List.of(QuizLevel.EASY, QuizLevel.NORMAL, QuizLevel.HARD);

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
@@ -2,11 +2,11 @@ package com.example.cs25batch.batch.service;
 
 import com.example.cs25batch.batch.dto.QuizDto;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
-import com.example.cs25entity.domain.quiz.entity.QuizAccuracy;
 import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
-import com.example.cs25entity.domain.quiz.repository.QuizAccuracyRedisRepository;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
@@ -14,7 +14,9 @@ import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,35 +34,59 @@ public class TodayQuizService {
     private final QuizRepository quizRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final UserQuizAnswerRepository userQuizAnswerRepository;
-    private final QuizAccuracyRedisRepository quizAccuracyRedisRepository;
     private final BatchMailService mailService;
 
     @Transactional
     public QuizDto getTodayQuiz(Long subscriptionId) {
-        //해당 구독자의 문제 구독 카테고리 확인
+        // 1. 구독자 정보 및 카테고리 조회
         Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
+        Long parentCategoryId = subscription.getCategory().getId(); // 대분류 ID
 
-        List<Quiz> quizList = quizRepository.findAllByCategoryId(
-                subscription.getCategory().getId())
-            .stream()
-            .sorted(Comparator.comparing(Quiz::getId))
-            .toList();
+        // 2. 유저 정답률 계산
+        List<UserQuizAnswer> answerHistory = userQuizAnswerRepository.findByUserIdAndQuizCategoryId(
+            subscriptionId, parentCategoryId);
+        double accuracy = calculateAccuracy(answerHistory);
 
+        // 3. 정답률 기반 난이도 바운더리 설정
+        List<QuizLevel> allowedDifficulties = getAllowedDifficulties(accuracy);
 
-        if (quizList.isEmpty()) {
+        //4. 가장 최근에 푼 문제 소분류 카테고리 지워줘야해
+        Set<Long> excludedCategoryIds = userQuizAnswerRepository.findRecentSolvedCategoryIds(
+            subscriptionId,
+            parentCategoryId,
+            LocalDate.now().minusDays(1)  // ← 이거 몇일 중복 제거할건지 설정가능쓰
+        );
+
+        // 5. 내가 푼 문제 ID
+        Set<Long> solvedQuizIds = answerHistory.stream()
+            .map(a -> a.getQuiz().getId())
+            .collect(Collectors.toSet());
+
+        // 6. 서술형 주기 판단 (풀이 횟수 기반)
+        int quizCount = answerHistory.size(); // 사용자가 지금까지 푼 문제 수
+        boolean isEssayDay = quizCount % 5 == 4;
+
+        List<QuizFormatType> targetTypes = isEssayDay
+            ? List.of(QuizFormatType.SUBJECTIVE)
+            : List.of(QuizFormatType.MULTIPLE_CHOICE, QuizFormatType.SHORT_ANSWER);
+
+        // 7. 필터링 조건으로 문제 조회
+        List<Quiz> candidateQuizzes = quizRepository.findAvailableQuizzesUnderParentCategory(
+            parentCategoryId,
+            allowedDifficulties,
+            solvedQuizIds,
+            excludedCategoryIds,
+            targetTypes
+        );
+
+        if (candidateQuizzes.isEmpty()) {
             throw new QuizException(QuizExceptionCode.NO_QUIZ_EXISTS_ERROR);
         }
 
-        // 구독 시작일 기준 날짜 차이 계산
-        LocalDate createdDate = subscription.getCreatedAt().toLocalDate();
-        LocalDate today = LocalDate.now();
-        long daysSinceCreated = ChronoUnit.DAYS.between(createdDate, today);
+        // 8. 오프셋 계산 (풀이 수 기준)
+        long offset = quizCount % candidateQuizzes.size();
+        Quiz selectedQuiz = candidateQuizzes.get((int) offset);
 
-        // 슬라이딩 인덱스로 문제 선택
-        int offset = Math.toIntExact((subscriptionId + daysSinceCreated) % quizList.size());
-        Quiz selectedQuiz = quizList.get(offset);
-
-        //return selectedQuiz;
         return QuizDto.builder()
             .id(selectedQuiz.getId())
             .quizCategory(selectedQuiz.getCategory().getCategoryType())
@@ -69,6 +95,24 @@ public class TodayQuizService {
             .type(selectedQuiz.getType())
             .build();  //return -> QuizDto
     }
+
+    //유저 정답률 기준으로 바운더리 정해줌
+    private List<QuizLevel> getAllowedDifficulties(double accuracy) {
+        // 난이도 낮
+        if (accuracy <= 0.5) {
+            return List.of(QuizLevel.EASY);
+        } else if (accuracy <= 0.75) { //난이도 중
+            return List.of(QuizLevel.EASY, QuizLevel.NORMAL);
+        } else { //난이도 상
+            return List.of(QuizLevel.EASY, QuizLevel.NORMAL, QuizLevel.HARD);
+        }
+    }
+//
+//    private long calculateOffset(Long subscriptionId, LocalDateTime createdAt, int size) {
+//        long daysSince = ChronoUnit.DAYS.between(createdAt.toLocalDate(), LocalDate.now());
+//        return (subscriptionId + daysSince) % size;
+//    }
+
 
     @Transactional
     public Quiz getTodayQuizBySubscription(Subscription subscription) {
@@ -102,55 +146,78 @@ public class TodayQuizService {
         return quizList.get(offset);
     }
 
-    @Transactional
-    public QuizDto getTodayQuizNew(Long subscriptionId) {
-        //1. 해당 구독자의 문제 구독 카테고리 확인
-        Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
-        Long categoryId = subscription.getCategory().getId();
+//    @Transactional
+//    public QuizDto getTodayQuizNew(Long subscriptionId) {
+    /// ////////////////////여기는 구구 버전//////////////////////
+    //        List<Quiz> quizList = quizRepository.findAllByCategoryId(
+//                subscription.getCategory().getId())
+//            .stream()
+//            .sorted(Comparator.comparing(Quiz::getId))
+//            .toList();
+//
+//
+//        if (quizList.isEmpty()) {
+//            throw new QuizException(QuizExceptionCode.NO_QUIZ_EXISTS_ERROR);
+//        }
+//
+//        // 구독 시작일 기준 날짜 차이 계산
+//        LocalDate createdDate = subscription.getCreatedAt().toLocalDate();
+//        LocalDate today = LocalDate.now();
+//        long daysSinceCreated = ChronoUnit.DAYS.between(createdDate, today);
+//
+//        // 슬라이딩 인덱스로 문제 선택
+//        int offset = Math.toIntExact((subscriptionId + daysSinceCreated) % quizList.size());
+//        Quiz selectedQuiz = quizList.get(offset);
 
-        // 2. 유저의 정답률 계산
-        List<UserQuizAnswer> answers = userQuizAnswerRepository.findByUserIdAndCategoryId(
-            subscriptionId,
-            categoryId);
-        double userAccuracy = calculateAccuracy(answers); // 정답 수 / 전체 수
+    //return selectedQuiz;
 
-        log.info("✳ getTodayQuizNew  유저의 정답률 계산 : {}", userAccuracy);
-        // 3. Redis에서 정답률 리스트 가져오기
-        List<QuizAccuracy> accuracyList = quizAccuracyRedisRepository.findAllByCategoryId(
-            categoryId);
-        //  QuizAccuracy 리스트를 Map<quizId, accuracy>로 변환
-        Map<Long, Double> quizAccuracyMap = accuracyList.stream()
-            .collect(Collectors.toMap(QuizAccuracy::getQuizId, QuizAccuracy::getAccuracy));
-
-        // 4. 유저가 푼 문제 ID 목록
-        Set<Long> solvedQuizIds = answers.stream()
-            .map(answer -> answer.getQuiz().getId())
-            .collect(Collectors.toSet());
-
-        // 5. 가장 비슷한 정답률을 가진 안푼 문제 찾기
-        Quiz selectedQuiz = quizAccuracyMap.entrySet().stream()
-            .filter(entry -> !solvedQuizIds.contains(entry.getKey()))
-            .min(Comparator.comparingDouble(entry -> Math.abs(entry.getValue() - userAccuracy)))
-            .flatMap(entry -> quizRepository.findById(entry.getKey()))
-            .orElse(null); // 없으면 null 또는 랜덤
-
-        if (selectedQuiz == null) {
-            throw new QuizException(QuizExceptionCode.NO_QUIZ_EXISTS_ERROR);
-        }
-        //return selectedQuiz;   //return -> Quiz
-        return QuizDto.builder()
-            .id(selectedQuiz.getId())
-            .quizCategory(selectedQuiz.getCategory().getCategoryType())
-            .question(selectedQuiz.getQuestion())
-            .choice(selectedQuiz.getChoice())
-            .type(selectedQuiz.getType())
-            .build(); //return -> QuizDto
-
-    }
-
+    /// /////////////////////여기는 구버전 /////////////////////////////
+//        //1. 해당 구독자의 문제 구독 카테고리 확인
+//        Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
+//        Long categoryId = subscription.getCategory().getId();
+//
+//        // 2. 유저의 정답률 계산
+//        List<UserQuizAnswer> answers = userQuizAnswerRepository.findByUserIdAndCategoryId(
+//            subscriptionId,
+//            categoryId);
+//        double userAccuracy = calculateAccuracy(answers); // 정답 수 / 전체 수
+//
+//        log.info("✳ getTodayQuizNew  유저의 정답률 계산 : {}", userAccuracy);
+//        // 3. Redis에서 정답률 리스트 가져오기
+//        List<QuizAccuracy> accuracyList = quizAccuracyRedisRepository.findAllByCategoryId(
+//            categoryId);
+//        //  QuizAccuracy 리스트를 Map<quizId, accuracy>로 변환
+//        Map<Long, Double> quizAccuracyMap = accuracyList.stream()
+//            .collect(Collectors.toMap(QuizAccuracy::getQuizId, QuizAccuracy::getAccuracy));
+//
+//        // 4. 유저가 푼 문제 ID 목록
+//        Set<Long> solvedQuizIds = answers.stream()
+//            .map(answer -> answer.getQuiz().getId())
+//            .collect(Collectors.toSet());
+//
+//        // 5. 가장 비슷한 정답률을 가진 안푼 문제 찾기
+//        Quiz selectedQuiz = quizAccuracyMap.entrySet().stream()
+//            .filter(entry -> !solvedQuizIds.contains(entry.getKey()))
+//            .min(Comparator.comparingDouble(entry -> Math.abs(entry.getValue() - userAccuracy)))
+//            .flatMap(entry -> quizRepository.findById(entry.getKey()))
+//            .orElse(null); // 없으면 null 또는 랜덤
+//
+//        if (selectedQuiz == null) {
+//            throw new QuizException(QuizExceptionCode.NO_QUIZ_EXISTS_ERROR);
+//        }
+//        //return selectedQuiz;   //return -> Quiz
+//        return QuizDto.builder()
+//            .id(selectedQuiz.getId())
+//            .quizCategory(selectedQuiz.getCategory().getCategoryType())
+//            .question(selectedQuiz.getQuestion())
+//            .choice(selectedQuiz.getChoice())
+//            .type(selectedQuiz.getType())
+//            .build(); //return -> QuizDto
+//
+//    }
     private double calculateAccuracy(List<UserQuizAnswer> answers) {
         if (answers.isEmpty()) {
-            return 0.0;
+            return 100.0;
         }
 
         int totalCorrect = 0;

--- a/cs25-entity/src/main/java/com/example/cs25entity/config/QuerydslConfig.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.cs25entity.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/repository/MailLogCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/repository/MailLogCustomRepositoryImpl.java
@@ -5,23 +5,18 @@ import com.example.cs25entity.domain.mail.entity.MailLog;
 import com.example.cs25entity.domain.mail.entity.QMailLog;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-public class MailLogCustomRepositoryImpl implements MailLogCustomRepository{
-    private final EntityManager entityManager;
-    private final JPAQueryFactory queryFactory;
+@RequiredArgsConstructor
+public class MailLogCustomRepositoryImpl implements MailLogCustomRepository {
 
-    public MailLogCustomRepositoryImpl(EntityManager entityManager) {
-        this.entityManager = entityManager;
-        this.queryFactory = new JPAQueryFactory(entityManager);
-    }
+    private final JPAQueryFactory queryFactory;
 
     @Override
     @Transactional(readOnly = true)

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepository.java
@@ -1,0 +1,17 @@
+package com.example.cs25entity.domain.quiz.repository;
+
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
+import java.util.List;
+import java.util.Set;
+
+public interface QuizCustomRepository {
+
+    List<Quiz> findAvailableQuizzesUnderParentCategory(Long parentCategoryId,
+        List<QuizLevel> difficulties,
+        Set<Long> solvedQuizIds,
+        Set<Long> recentQuizIds,
+        List<QuizFormatType> targetTypes);
+
+}

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.example.cs25entity.domain.quiz.repository;
+
+import com.example.cs25entity.domain.quiz.entity.QQuiz;
+import com.example.cs25entity.domain.quiz.entity.QQuizCategory;
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QuizCustomRepositoryImpl implements QuizCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Quiz> findAvailableQuizzesUnderParentCategory(Long parentCategoryId,
+        List<QuizLevel> difficulties,
+        Set<Long> solvedQuizIds,
+        Set<Long> recentQuizIds,
+        List<QuizFormatType> targetTypes) {
+
+        QQuiz quiz = QQuiz.quiz;
+        QQuizCategory category = QQuizCategory.quizCategory;
+
+        // 1. 소분류 ID들 가져오기
+        List<Long> subCategoryIds = queryFactory
+            .select(category.id)
+            .from(category)
+            .where(category.parent.id.eq(parentCategoryId))
+            .fetch();
+
+        if (subCategoryIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 퀴즈 조회
+        BooleanBuilder builder = new BooleanBuilder()
+            .and(quiz.category.id.in(subCategoryIds)) //내가 정한 카테고리에
+            .and(quiz.level.in(difficulties)) //정해진 난이도 그룹안에있으면서
+            .and(quiz.type.in(targetTypes)); //퀴즈 타입은 이거야
+
+        if (!solvedQuizIds.isEmpty()) {
+            builder.and(quiz.id.notIn(solvedQuizIds)); //혹시라도 구독자가 문제를 푼 이력잉 ㅣㅆ으면 그것도 제외해야햄
+        }
+
+        if (!recentQuizIds.isEmpty()) {
+            builder.and(quiz.category.id.notIn(recentQuizIds)); //거뭐냐 가장
+        }
+
+        return queryFactory
+            .selectFrom(quiz)
+            .where(builder)
+            .orderBy(quiz.id.asc())
+            .fetch();
+    }
+
+}

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizRepository.java
@@ -11,9 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
-
-    List<Quiz> findAllByCategoryId(Long categoryId);
+public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizCustomRepository {
 
     List<Quiz> findAllByCategoryIdIn(Collection<Long> categoryIds);
 
@@ -21,4 +19,5 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     Page<Quiz> findAllOrderByCreatedAtDesc(Pageable pageable);
 
     Optional<Quiz> findBySerialId(String quizId);
+
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/entity/User.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/entity/User.java
@@ -100,4 +100,8 @@ public class User extends BaseEntity {
     public void updateScore(double score) {
         this.score = score;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepository.java
@@ -2,14 +2,15 @@ package com.example.cs25entity.domain.userQuizAnswer.repository;
 
 import com.example.cs25entity.domain.userQuizAnswer.dto.UserAnswerDto;
 import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
+import java.time.LocalDate;
 import java.util.List;
-import org.springframework.stereotype.Repository;
+import java.util.Set;
 
 public interface UserQuizAnswerCustomRepository {
-
-    List<UserQuizAnswer> findByUserIdAndCategoryId(Long userId, Long categoryId);
-
+    
     List<UserAnswerDto> findUserAnswerByQuizId(Long quizId);
 
     List<UserQuizAnswer> findByUserIdAndQuizCategoryId(Long userId, Long quizCategoryId);
+
+    Set<Long> findRecentSolvedCategoryIds(Long userId, Long parentCategoryId, LocalDate afterDate);
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepositoryImpl.java
@@ -2,42 +2,39 @@ package com.example.cs25entity.domain.userQuizAnswer.repository;
 
 import com.example.cs25entity.domain.quiz.entity.QQuiz;
 import com.example.cs25entity.domain.quiz.entity.QQuizCategory;
-import com.example.cs25entity.domain.subscription.entity.QSubscription;
 import com.example.cs25entity.domain.userQuizAnswer.dto.UserAnswerDto;
 import com.example.cs25entity.domain.userQuizAnswer.entity.QUserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class UserQuizAnswerCustomRepositoryImpl implements UserQuizAnswerCustomRepository {
 
-    private final EntityManager entityManager;
     private final JPAQueryFactory queryFactory;
 
-    public UserQuizAnswerCustomRepositoryImpl(EntityManager entityManager) {
-        this.entityManager = entityManager;
-        this.queryFactory = new JPAQueryFactory(entityManager);
-    }
-
-    @Override
-    public List<UserQuizAnswer> findByUserIdAndCategoryId(Long userId, Long categoryId) {
-        QUserQuizAnswer answer = QUserQuizAnswer.userQuizAnswer;
-        QSubscription subscription = QSubscription.subscription;
-        QQuizCategory category = QQuizCategory.quizCategory;
-        //테이블이 세개 싹 조인갈겨
-
-        return queryFactory
-            .selectFrom(answer)
-            .join(answer.subscription, subscription)
-            .join(subscription.category, category)
-            .where(
-                answer.user.id.eq(userId),
-                category.id.eq(categoryId)
-            )
-            .fetch();
-    }
+//    @Override
+//    public List<UserQuizAnswer> findByUserIdAndCategoryId(Long userId, Long categoryId) {
+//        QUserQuizAnswer answer = QUserQuizAnswer.userQuizAnswer;
+//        QSubscription subscription = QSubscription.subscription;
+//        QQuizCategory category = QQuizCategory.quizCategory;
+//        //테이블이 세개 싹 조인갈겨
+//
+//        return queryFactory
+//            .selectFrom(answer)
+//            .join(answer.subscription, subscription)
+//            .join(subscription.category, category)
+//            .where(
+//                answer.user.id.eq(userId),
+//                category.id.eq(categoryId)
+//            )
+//            .fetch();
+//    }
 
     @Override
     public List<UserAnswerDto> findUserAnswerByQuizId(Long quizId) {
@@ -51,7 +48,7 @@ public class UserQuizAnswerCustomRepositoryImpl implements UserQuizAnswerCustomR
     }
 
     @Override
-    public List<UserQuizAnswer> findByUserIdAndQuizCategoryId(Long userId, Long quizCategoryId){
+    public List<UserQuizAnswer> findByUserIdAndQuizCategoryId(Long userId, Long quizCategoryId) {
         QUserQuizAnswer answer = QUserQuizAnswer.userQuizAnswer;
         QQuiz quiz = QQuiz.quiz;
         QQuizCategory category = QQuizCategory.quizCategory;
@@ -67,4 +64,23 @@ public class UserQuizAnswerCustomRepositoryImpl implements UserQuizAnswerCustomR
             .fetch();
     }
 
+    @Override
+    public Set<Long> findRecentSolvedCategoryIds(Long userId, Long parentCategoryId,
+        LocalDate afterDate) {
+        QUserQuizAnswer answer = QUserQuizAnswer.userQuizAnswer;
+        QQuiz quiz = QQuiz.quiz;
+        QQuizCategory category = QQuizCategory.quizCategory;
+
+        return new HashSet<>(queryFactory
+            .select(category.id)
+            .from(answer)
+            .join(answer.quiz, quiz)
+            .join(quiz.category, category)
+            .where(
+                answer.user.id.eq(userId),
+                category.parent.id.eq(parentCategoryId),
+                answer.createdAt.goe(afterDate.atStartOfDay())
+            )
+            .fetch());
+    }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
@@ -1,6 +1,7 @@
 package com.example.cs25service.domain.admin.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
+import com.example.cs25service.domain.admin.dto.request.UserRoleUpdateRequestDto;
 import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
 import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
 import com.example.cs25service.domain.admin.service.UserAdminService;
@@ -71,4 +72,16 @@ public class UserAdminController {
 
         return new ApiResponse<>(204);
     }
+
+    //PATCH  관리자의 권한 수정 /admin/users/{userId}/role
+    @PatchMapping("/{userId}/role")
+    public ApiResponse<Void> patchUserRole(
+        @Positive @PathVariable(name = "userId") Long userId,
+        @RequestBody @Valid UserRoleUpdateRequestDto request
+    ) {
+        userAdminService.patchUserRole(userId, request);
+        return new ApiResponse<>(204);
+    }
+
+
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/UserRoleUpdateRequestDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/UserRoleUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.cs25service.domain.admin.dto.request;
+
+import com.example.cs25entity.domain.user.entity.Role;
+import lombok.Getter;
+
+@Getter
+public class UserRoleUpdateRequestDto {
+
+    private Role role;
+
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/UserRoleUpdateRequestDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/UserRoleUpdateRequestDto.java
@@ -2,8 +2,10 @@ package com.example.cs25service.domain.admin.dto.request;
 
 import com.example.cs25entity.domain.user.entity.Role;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserRoleUpdateRequestDto {
 
     private Role role;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/service/UserAdminService.java
@@ -5,10 +5,12 @@ import static com.example.cs25entity.domain.subscription.entity.Subscription.dec
 import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.entity.SubscriptionHistory;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionHistoryRepository;
+import com.example.cs25entity.domain.user.entity.Role;
 import com.example.cs25entity.domain.user.entity.User;
 import com.example.cs25entity.domain.user.exception.UserException;
 import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.admin.dto.request.UserRoleUpdateRequestDto;
 import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
 import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionHistoryDto;
@@ -141,5 +143,18 @@ public class UserAdminService {
         }
 
         subscriptionService.cancelSubscription(user.getSubscription().getSerialId());
+    }
+
+    @Transactional
+    public void patchUserRole(@Positive Long userId, @Valid UserRoleUpdateRequestDto request) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+
+        Role requestRole = request.getRole();
+
+        if (requestRole == null) {
+            throw new UserException(UserExceptionCode.INVALID_ROLE);
+        } else if (!requestRole.equals(user.getRole())) {
+            user.updateRole(request.getRole());
+        }
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/crawler/service/CrawlerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/crawler/service/CrawlerService.java
@@ -1,11 +1,9 @@
 package com.example.cs25service.domain.crawler.service;
 
-import com.example.cs25entity.domain.user.entity.Role;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.ai.service.RagService;
 import com.example.cs25service.domain.crawler.github.GitHubRepoInfo;
 import com.example.cs25service.domain.crawler.github.GitHubUrlParser;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -17,8 +15,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.example.cs25service.domain.security.dto.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.document.Document;
 import org.springframework.core.ParameterizedTypeReference;
@@ -39,10 +35,10 @@ public class CrawlerService {
     private String githubToken;
 
     public void crawlingGithubDocument(AuthUser authUser, String url) {
-
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
-        }
+//
+//        if(authUser.getRole() != Role.ADMIN){
+//            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+//        }
 
         //url 에서 필요 정보 추출
         GitHubRepoInfo repoInfo = GitHubUrlParser.parseGitHubUrl(url);

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizCategoryService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizCategoryService.java
@@ -5,13 +5,9 @@ import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
-import com.example.cs25entity.domain.user.entity.Role;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.quiz.dto.CreateQuizCategoryDto;
-import java.util.List;
-
 import com.example.cs25service.domain.security.dto.AuthUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,9 +23,9 @@ public class QuizCategoryService {
     @Transactional
     public void createQuizCategory(AuthUser authUser, CreateQuizCategoryDto request) {
 
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
-        }
+//        if(authUser.getRole() != Role.ADMIN){
+//            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+//        }
 
         quizCategoryRepository.findByCategoryType(request.getCategory())
             .ifPresent(c -> {
@@ -41,7 +37,8 @@ public class QuizCategoryService {
             parent = quizCategoryRepository.findById(request.getParentId())
                 .orElseThrow(() ->
                     new QuizException(QuizExceptionCode.PARENT_QUIZ_CATEGORY_NOT_FOUND_ERROR));
-        };
+        }
+        ;
 
         QuizCategory quizCategory = QuizCategory.builder()
             .categoryType(request.getCategory())

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizService.java
@@ -7,11 +7,7 @@ import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
-import com.example.cs25entity.domain.user.entity.Role;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25service.domain.quiz.dto.CreateQuizDto;
-import com.example.cs25service.domain.quiz.dto.QuizResponseDto;
 import com.example.cs25service.domain.security.dto.AuthUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
@@ -42,15 +38,15 @@ public class QuizService {
 
     @Transactional
     public void uploadQuizJson(
-            AuthUser authUser,
-            MultipartFile file,
-            String categoryType,
-            QuizFormatType formatType
+        AuthUser authUser,
+        MultipartFile file,
+        String categoryType,
+        QuizFormatType formatType
     ) {
 
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
-        }
+//        if(authUser.getRole() != Role.ADMIN){
+//            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+//        }
 
         try {
             //대분류 확인

--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/config/SecurityConfig.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.cs25service.domain.oauth2.service.CustomOAuth2UserService;
 import com.example.cs25service.domain.security.jwt.filter.JwtAuthenticationFilter;
 import com.example.cs25service.domain.security.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -17,7 +18,6 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -30,7 +30,7 @@ public class SecurityConfig {
     private static final String[] PERMITTED_ROLES = {"USER", "ADMIN"};
     private final JwtTokenProvider jwtTokenProvider;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-    
+
     @Value("${FRONT_END_URI:http://localhost:5173}")
     private String frontEndUri;
 
@@ -41,7 +41,7 @@ public class SecurityConfig {
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);
-        
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
@@ -74,9 +74,12 @@ public class SecurityConfig {
                 //로그인이 필요한 서비스만 여기다가 추가하기 (permaiAll 은 패싱 ㄱㄱ)
                 .requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole(PERMITTED_ROLES)
                 .requestMatchers(HttpMethod.POST, "/quizzes/upload/**")
-                .hasAnyRole(PERMITTED_ROLES) //퀴즈 업로드 - 추후 ADMIN으로 변경
+                .hasRole("ADMIN")//퀴즈 업로드 - 추후 ADMIN으로 변경
+
                 .requestMatchers(HttpMethod.POST, "/auth/**").hasAnyRole(PERMITTED_ROLES)
                 .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/quiz-categories/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/crawlers/github/**").hasRole("ADMIN")
 
                 .anyRequest().permitAll()
             )


### PR DESCRIPTION


## 🔎 작업 내용

- 사용자는 존재하는 모든 문제를 풀지 않는 이상 중복 문제를 받지 않는다.
- 사용자는 같은 카테고리 문제를 2일 연속 받지않는다.
- 사용자의 문제 풀이 이력을 기준으로 정답률 50% 까지는 EASY문제를, 70% 까지는 EASY, NORMAL 문제를, 100%까지는 EASY, NORMAL, HARD 문제를 출제한다.
- 모든 사용자마다 정답률이 다르며, 사용자의 문제 풀이 이력이 없을 시엔 정답률은 100%로 간주된다.
- 문제유형에서 객관식/단답형과 서술형은 규칙에 따라서 4:1비율로 출제된다.
---

## 🛠️ 변경 사항

- getTodayQuiz 함수만 사용.
- getTodayQuizNew는 주석처리해놧음. 연관된 함수도 주석주석

---

## 🧯 해결해야 할 문제

- 이전보다 알고리즘 변경때문에 조인과 조회가 좀 많아졌음. .... redis를 사용해서 줄일 수 있을까?

---

## 📌 참고 사항

- 테스트 못해봄
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자가 사용자 역할을 변경할 수 있는 PATCH API가 추가되었습니다.
  - 사용자 역할 변경 요청을 위한 DTO가 추가되었습니다.

- **버그 수정**
  - 퀴즈 추천 로직이 사용자 정확도, 최근 풀이 기록, 형식 순환 등을 반영하여 더욱 정교하게 개선되었습니다.
  - 퀴즈 선택 시 최근 풀이한 카테고리와 이미 푼 문제를 제외하도록 변경되었습니다.

- **리팩터링**
  - Querydsl 설정 및 관련 리포지토리 구현이 개선되어 코드 구조가 단순화되었습니다.
  - 일부 불필요한 메서드와 필드가 제거되고, 생성자 주입 방식이 일관되게 적용되었습니다.

- **권한 및 보안**
  - 퀴즈 업로드, 카테고리 생성, 크롤러 실행 등 일부 POST 엔드포인트가 관리자만 접근 가능하도록 권한이 강화되었습니다.
  - 서비스 내 일부 역할 체크 로직이 주석 처리되어 일시적으로 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->