### PR TITLE
Fix: AI 피드백 응답 SSE에서 기존 방식으로, 카테고리 대분류/소분류 추출 로직 반대로 된거 수정

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
@@ -23,15 +23,16 @@ public class AiController {
     private final AiQuestionGeneratorService aiQuestionGeneratorService;
     private final FileLoaderService fileLoaderService;
 
-    @GetMapping(value = "/{answerId}/feedback", produces = "text/event-stream")
-    public SseEmitter streamFeedback(@PathVariable Long answerId) {
-        return aiService.streamFeedback(answerId);
+    @GetMapping("/{answerId}/feedback")
+    public ApiResponse<AiFeedbackResponse> streamFeedback(@PathVariable Long answerId) {
+        // TODO: aiService.streamFeedback(answerId);로 추후 수정예정
+        return new ApiResponse<>(200, aiService.getFeedback(answerId));
     }
 
     @GetMapping("/generate")
-    public ResponseEntity<?> generateQuiz() {
+    public ApiResponse<Quiz> generateQuiz() {
         Quiz quiz = aiQuestionGeneratorService.generateQuestionFromContext();
-        return ResponseEntity.ok(new ApiResponse<>(200, quiz));
+        return new ApiResponse<>(200, quiz);
     }
 
     @GetMapping("/load/{dirName}")

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/dto/QuizCategoryResponseDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/dto/QuizCategoryResponseDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuizCategoryResponseDto {
 	private final String main; // 대분류
-	private final String sub; // 소분
+	private final String sub; // 소분류
 
 	private QuizCategoryResponseDto(String main, String sub) {
 		this.main = main;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
@@ -84,7 +84,7 @@ public class QuizPageService {
      */
     private QuizCategoryResponseDto getQuizCategory(Quiz quiz) {
         // 대분류만 있을 경우
-        if (quiz.getCategory().isChildCategory()) {
+        if (!quiz.getCategory().isChildCategory()) {
             return QuizCategoryResponseDto.builder()
                 .main(quiz.getCategory().getCategoryType())
                 .build();


### PR DESCRIPTION

## 🔎 작업 내용

- AI 피드백 기존 방식으로 변경함
추후에 SSE 방식으로 변경 예정
- 카테고리 대분류/소분류 추출 로직 제대로 되게 수정

---


### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 피드백 조회 및 퀴즈 생성 시 응답 형식이 개선되어, 보다 일관성 있는 결과를 제공합니다.
  - 퀴즈 카테고리 반환 로직이 올바르게 동작하도록 수정되어, 메인 및 서브 카테고리 정보가 정확하게 표시됩니다.

- **문서화**
  - 퀴즈 카테고리 관련 설명이 더 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->