### PR TITLE
chore: 오늘의 문제뽑기 성능 개선

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
@@ -47,13 +47,6 @@ public class TodayQuizService {
             subscriptionId, parentCategoryId);
         double accuracy = calculateAccuracy(answerHistory);
 
-        //4. 가장 최근에 푼 문제 소분류 카테고리 지워줘야해
-        Set<Long> excludedCategoryIds = userQuizAnswerRepository.findRecentSolvedCategoryIds(
-            subscriptionId,
-            parentCategoryId,
-            LocalDate.now().minusDays(1)  // 이거 몇일 중복 제거할건지 설정가능쓰
-        );
-
         // 5. 내가 푼 문제 ID
         Set<Long> solvedQuizIds = answerHistory.stream()
             .map(a -> a.getQuiz().getId())
@@ -75,7 +68,7 @@ public class TodayQuizService {
             parentCategoryId,
             allowedDifficulties,
             solvedQuizIds,
-            excludedCategoryIds,
+            //excludedCategoryIds,
             targetTypes
         ); //한개만뽑기(find first)
 
@@ -95,6 +88,7 @@ public class TodayQuizService {
             .type(selectedQuiz.getType())
             .build();  //return -> QuizDto
     }
+
 
     //유저 정답률 기준으로 바운더리 정해줌
     private List<QuizLevel> getAllowedDifficulties(double accuracy) {

--- a/cs25-batch/src/test/java/com/example/cs25batch/batch/service/TodayQuizServiceTest.java
+++ b/cs25-batch/src/test/java/com/example/cs25batch/batch/service/TodayQuizServiceTest.java
@@ -2,7 +2,6 @@ package com.example.cs25batch.batch.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -117,8 +116,10 @@ class TodayQuizServiceTest {
                     LocalDate.class)))
                 .willReturn(recentCategoryIds);
             given(quizRepository.findAvailableQuizzesUnderParentCategory(eq(parentCategoryId),
-                anyList()
-                , eq(solvedQuizIds), eq(recentCategoryIds), anyList())).willReturn(
+                eq(List.of(QuizLevel.NORMAL, QuizLevel.EASY))
+                , eq(solvedQuizIds)
+                , eq(List.of(QuizFormatType.SHORT_ANSWER,
+                    QuizFormatType.MULTIPLE_CHOICE)))).willReturn(
                 availableQuizzes);
 
             //when

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepository.java
@@ -11,7 +11,6 @@ public interface QuizCustomRepository {
     List<Quiz> findAvailableQuizzesUnderParentCategory(Long parentCategoryId,
         List<QuizLevel> difficulties,
         Set<Long> solvedQuizIds,
-        Set<Long> recentQuizIds,
         List<QuizFormatType> targetTypes);
 
 }

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -20,7 +20,6 @@ public class QuizCustomRepositoryImpl implements QuizCustomRepository {
     public List<Quiz> findAvailableQuizzesUnderParentCategory(Long parentCategoryId,
         List<QuizLevel> difficulties,
         Set<Long> solvedQuizIds,
-        Set<Long> recentQuizIds,
         List<QuizFormatType> targetTypes) {
 
         QQuiz quiz = QQuiz.quiz;
@@ -45,10 +44,6 @@ public class QuizCustomRepositoryImpl implements QuizCustomRepository {
 
         if (!solvedQuizIds.isEmpty()) {
             builder.and(quiz.id.notIn(solvedQuizIds)); //혹시라도 구독자가 문제를 푼 이력잉 ㅣㅆ으면 그것도 제외해야햄
-        }
-
-        if (!recentQuizIds.isEmpty()) {
-            builder.and(quiz.category.id.notIn(recentQuizIds)); //거뭐냐 가장
         }
 
         return queryFactory

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizTestController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizTestController.java
@@ -1,11 +1,9 @@
 package com.example.cs25service.domain.quiz.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
-import com.example.cs25service.domain.quiz.dto.test.QuizDto;
 import com.example.cs25service.domain.quiz.service.QuizAccuracyCalculateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,11 +18,11 @@ public class QuizTestController {
         return new ApiResponse<>(200);
     }
 
-    @GetMapping("/accuracyTest/getTodayQuiz/{subscriptionId}")
-    public ApiResponse<QuizDto> getTodayQuiz(
-        @PathVariable(name = "subscriptionId") Long subscriptionId
-    ) {
-        return new ApiResponse<>(200, accuracyService.getTodayQuiz(subscriptionId));
-    }
+//    @GetMapping("/accuracyTest/getTodayQuiz/{subscriptionId}")
+//    public ApiResponse<QuizDto> getTodayQuiz(
+//        @PathVariable(name = "subscriptionId") Long subscriptionId
+//    ) {
+//        return new ApiResponse<>(200, accuracyService.getTodayQuiz(subscriptionId));
+//    }
 
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizAccuracyCalculateService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizAccuracyCalculateService.java
@@ -2,26 +2,15 @@ package com.example.cs25service.domain.quiz.service;
 
 import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.quiz.entity.QuizAccuracy;
-import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
-import com.example.cs25entity.domain.quiz.enums.QuizLevel;
-import com.example.cs25entity.domain.quiz.exception.QuizException;
-import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizAccuracyRedisRepository;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
-import com.example.cs25entity.domain.subscription.entity.Subscription;
-import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
 import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
-import com.example.cs25service.domain.quiz.dto.test.QuizDto;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -31,7 +20,6 @@ public class QuizAccuracyCalculateService {
     private final QuizRepository quizRepository;
     private final QuizAccuracyRedisRepository quizAccuracyRedisRepository;
     private final UserQuizAnswerRepository userQuizAnswerRepository;
-    private final SubscriptionRepository subscriptionRepository;
 
 
     public void calculateAndCacheAllQuizAccuracies() {
@@ -57,93 +45,5 @@ public class QuizAccuracyCalculateService {
         log.info("총 {}개의 정답률 캐싱 완료", accuracyList.size());
         quizAccuracyRedisRepository.saveAll(accuracyList);
     }
-
-
-    @Transactional
-    public QuizDto getTodayQuiz(Long subscriptionId) {
-        // 1. 구독자 정보 및 카테고리 조회
-        Subscription subscription = subscriptionRepository.findByIdOrElseThrow(subscriptionId);
-        Long parentCategoryId = subscription.getCategory().getId(); // 대분류 ID
-
-        // 2. 유저 정답률 계산
-        List<UserQuizAnswer> answerHistory = userQuizAnswerRepository.findByUserIdAndQuizCategoryId(
-            subscriptionId, parentCategoryId);
-        double accuracy = calculateAccuracy(answerHistory);
-
-        //4. 가장 최근에 푼 문제 소분류 카테고리 지워줘야해
-        Set<Long> excludedCategoryIds = userQuizAnswerRepository.findRecentSolvedCategoryIds(
-            subscriptionId,
-            parentCategoryId,
-            LocalDate.now().minusDays(1)  // 이거 몇일 중복 제거할건지 설정가능쓰
-        );
-
-        // 5. 내가 푼 문제 ID
-        Set<Long> solvedQuizIds = answerHistory.stream()
-            .map(a -> a.getQuiz().getId())
-            .collect(Collectors.toSet());
-
-        // 6. 서술형 주기 판단 (풀이 횟수 기반)
-        int quizCount = answerHistory.size(); // 사용자가 지금까지 푼 문제 수
-        boolean isEssayDay = quizCount % 5 == 4; //일단 5배수일때 한번씩은 서술 뽑아줘야함( 조정 필요하면 나중에 하는거롤)
-
-        List<QuizFormatType> targetTypes = isEssayDay
-            ? List.of(QuizFormatType.SUBJECTIVE)
-            : List.of(QuizFormatType.MULTIPLE_CHOICE, QuizFormatType.SHORT_ANSWER);
-
-        // 3. 정답률 기반 난이도 바운더리 설정
-        List<QuizLevel> allowedDifficulties = getAllowedDifficulties(accuracy);
-
-        // 7. 필터링 조건으로 문제 조회(대분류, 난이도, 내가푼문제 제외, 제외할 카테고리 제외하고, 문제 타입 전부 조건으로)
-        List<Quiz> candidateQuizzes = quizRepository.findAvailableQuizzesUnderParentCategory(
-            parentCategoryId,
-            allowedDifficulties,
-            solvedQuizIds,
-            excludedCategoryIds,
-            targetTypes
-        ); //한개만뽑기(find first)
-
-        if (candidateQuizzes.isEmpty()) { // 뽀ㅃ을문제없을때
-            throw new QuizException(QuizExceptionCode.NO_QUIZ_EXISTS_ERROR);
-        }
-
-        // 8. 오프셋 계산 (풀이 수 기준)
-        long offset = quizCount % candidateQuizzes.size();
-        Quiz selectedQuiz = candidateQuizzes.get((int) offset);
-
-        return QuizDto.builder()
-            .id(selectedQuiz.getId())
-            .quizCategory(selectedQuiz.getCategory().getCategoryType())
-            .question(selectedQuiz.getQuestion())
-            .choice(selectedQuiz.getChoice())
-            .type(selectedQuiz.getType())
-            .build();  //return -> QuizDto
-    }
-
-    //유저 정답률 기준으로 바운더리 정해줌
-    private List<QuizLevel> getAllowedDifficulties(double accuracy) {
-        // 난이도 낮
-        if (accuracy <= 50.0) {
-            return List.of(QuizLevel.EASY);
-        } else if (accuracy <= 75.0) { //난이도 중
-            return List.of(QuizLevel.EASY, QuizLevel.NORMAL);
-        } else { //난이도 상
-            return List.of(QuizLevel.EASY, QuizLevel.NORMAL, QuizLevel.HARD);
-        }
-    }
-
-    private double calculateAccuracy(List<UserQuizAnswer> answers) {
-        if (answers.isEmpty()) {
-            return 100.0;
-        }
-
-        int totalCorrect = 0;
-        for (UserQuizAnswer answer : answers) {
-            if (answer.getIsCorrect()) {
-                totalCorrect++;
-            }
-        }
-        return ((double) totalCorrect / answers.size()) * 100.0;
-    }
-
 
 }

--- a/k6/scripts/test.js
+++ b/k6/scripts/test.js
@@ -2,11 +2,12 @@ import http from 'k6/http';
 
 export const options = {
   vus: 50,              // 동시 실행자 수 (스레드 개념)
-  iterations: 10000,     // 총 요청 수
+  iterations: 9900,     // 총 요청 수
 };
 
 export default function () {
-  const subscriptionId = __ITER; // 1부터 10000까지
+  const subscriptionId = __ITER + 10; // 1부터 10000까지
   http.get(
       `http://host.docker.internal:8080/accuracyTest/getTodayQuiz/${subscriptionId}`);
+
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 카테고리 빼는거 그냥 제외시켰음.
- Offset 설정하는게 아니라 같은 바운더리의 사람들은 같은 문제를 받도록 했음.. (OOE 에러가 나기떄문)

---

## 🛠️ 변경 사항

- db 조회횟수 줄임
![image](https://github.com/user-attachments/assets/4b232099-1310-4990-bff7-136b57a1442d)


---

## 🧩 트러블 슈팅
- time out 아직 해결못했는데 오류 율이 1만건에 40개정도 (0.4%) + 유저가 직접 요청하는 부분이 아니다보니 튜터님이 이정도면 괜찮을 것 같다고 하셔ㅑㅆ음.
---

## 🧯 해결해야 할 문제
- 성능개선이랄게 없다는 문제.... 헛수고만 엄청했다.
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 오늘의 퀴즈에서 최근에 푼 하위 카테고리 제외 로직이 제거되어, 최근에 푼 카테고리의 퀴즈도 다시 출제될 수 있습니다.
- **기능 변경**
	- 오늘의 퀴즈 관련 엔드포인트 및 서비스 기능이 비활성화 또는 제거되었습니다.
- **테스트**
	- 테스트 코드에서 퀴즈 레벨 및 형식 타입에 대한 검증이 더 엄격하게 변경되었습니다.
- **기타**
	- 부하 테스트 스크립트의 반복 횟수와 일부 테스트 파라미터가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->