### PR TITLE
Chore: Profile 프론트와 연동에서 필요한 부분 수정

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/dto/ProfileResponseDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/dto/ProfileResponseDto.java
@@ -1,19 +1,16 @@
 package com.example.cs25service.domain.profile.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProfileResponseDto {
-
     private final String name;
     private final double score;
     private final int rank;
-
-    @Builder
-    public ProfileResponseDto(String name, double score, int rank) {
-        this.name = name;
-        this.score = score;
-        this.rank = rank;
-    }
+    private final String subscriptionId;
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
@@ -106,6 +106,7 @@ public class ProfileService {
             .name(user.getName())
             .rank(myRank)
             .score(user.getScore())
+            .subscriptionId(user.getSubscription() == null ? null : user.getSubscription().getSerialId())
             .build();
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/users/controller/AuthController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/users/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +27,14 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenService tokenService;
+
+    @GetMapping("/status")
+    public ApiResponse<Boolean> checkLoginStatus(
+        @AuthenticationPrincipal AuthUser authUser
+    ) {
+        boolean isAuthenticated = authUser != null;
+        return new ApiResponse<>(200, isAuthenticated);
+    }
 
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<TokenResponseDto>> getSubscription(
@@ -40,7 +49,6 @@ public class AuthController {
                 tokenDto
             ));
     }
-
 
     @PostMapping("/logout")
     public ApiResponse<String> logout(@AuthenticationPrincipal AuthUser authUser,


### PR DESCRIPTION

## 🔎 작업 내용

- `/auth/status` API 요청 추가
- OAuth2 Client Success Handler 간단 수정
- Profile 응답 DTO에 `subscriptionId(UUID)` 추가

---

## 📌 참고 사항

- `/auth/status`는 프론트에서 로그인 되어있는지 확인하는 용도로 사용
- OAuth2 Client Success Handler 수정사항 봐주시면 좋을 듯

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 인증 상태를 확인할 수 있는 `/auth/status` 엔드포인트가 추가되었습니다.

* **버그 수정**
  * OAuth2 로그인 성공 시 발급되는 토큰 쿠키의 SameSite 속성이 "Lax"로 변경되었습니다.

* **개선 사항**
  * 프로필 조회 시 구독 ID 정보가 추가로 제공됩니다.
  * 프로필 응답에서 null 값 필드는 JSON에 포함되지 않습니다.
  * 내부 주석 및 로그 메시지가 보다 명확하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->