### PR TITLE
Refactor/189 : AI 피드백 SSE 토큰 단위로 실시간 전송하는 스트리밍 기능으로 리팩토링

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
@@ -2,6 +2,7 @@ package com.example.cs25service.domain.ai.client;
 
 import java.util.function.Consumer;
 import org.springframework.ai.chat.client.ChatClient;
+import reactor.core.publisher.Flux;
 
 public interface AiChatClient {
 
@@ -9,5 +10,5 @@ public interface AiChatClient {
 
     ChatClient raw();
 
-    void  stream(String systemPrompt,String userPrompt, Consumer<String> onToken);
+    Flux<String> stream(String systemPrompt,String userPrompt);
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/AiChatClient.java
@@ -1,5 +1,6 @@
 package com.example.cs25service.domain.ai.client;
 
+import java.util.function.Consumer;
 import org.springframework.ai.chat.client.ChatClient;
 
 public interface AiChatClient {
@@ -7,4 +8,6 @@ public interface AiChatClient {
     String call(String systemPrompt, String userPrompt);
 
     ChatClient raw();
+
+    void  stream(String systemPrompt,String userPrompt, Consumer<String> onToken);
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
 @Component
 @RequiredArgsConstructor
@@ -29,15 +30,13 @@ public class ClaudeChatClient implements AiChatClient {
     }
 
     @Override
-    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+    public Flux<String> stream(String systemPrompt, String userPrompt) {
         try {
-            anthropicChatClient.prompt()
+            return anthropicChatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
                 .stream()
-                .content()
-                .doOnNext(onToken)
-                .subscribe();
+                .content();
                 } catch (Exception e) {
             throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
         }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/ClaudeChatClient.java
@@ -1,7 +1,11 @@
 package com.example.cs25service.domain.ai.client;
 
+import com.example.cs25service.domain.ai.exception.AiException;
+import com.example.cs25service.domain.ai.exception.AiExceptionCode;
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,5 +26,20 @@ public class ClaudeChatClient implements AiChatClient {
     @Override
     public ChatClient raw() {
         return anthropicChatClient;
+    }
+
+    @Override
+    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+        try {
+            anthropicChatClient.prompt()
+                .system(systemPrompt)
+                .user(userPrompt)
+                .stream()
+                .content()
+                .doOnNext(onToken)
+                .subscribe();
+                } catch (Exception e) {
+            throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
 @Component("fallbackAiChatClient")
 @RequiredArgsConstructor
@@ -34,12 +35,12 @@ public class FallbackAiChatClient implements AiChatClient {
     }
 
     @Override
-    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+    public Flux<String> stream(String systemPrompt, String userPrompt) {
         try {
-            openAiClient.stream(systemPrompt, userPrompt, onToken);
+            return openAiClient.stream(systemPrompt, userPrompt);
         } catch (Exception e) {
             log.warn("OpenAI 스트리밍 실패. Claude로 폴백합니다.", e);
-            claudeClient.stream(systemPrompt, userPrompt, onToken);
+            return claudeClient.stream(systemPrompt, userPrompt);
         }
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/FallbackAiChatClient.java
@@ -1,5 +1,6 @@
 package com.example.cs25service.domain.ai.client;
 
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
@@ -31,5 +32,17 @@ public class FallbackAiChatClient implements AiChatClient {
     public org.springframework.ai.chat.client.ChatClient raw() {
         return openAiClient.raw(); // 기본은 OpenAI 기준
     }
+
+    @Override
+    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+        try {
+            openAiClient.stream(systemPrompt, userPrompt, onToken);
+        } catch (Exception e) {
+            log.warn("OpenAI 스트리밍 실패. Claude로 폴백합니다.", e);
+            claudeClient.stream(systemPrompt, userPrompt, onToken);
+        }
+    }
+
+
 }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
 @Component
 @RequiredArgsConstructor
@@ -33,15 +34,13 @@ public class OpenAiChatClient implements AiChatClient {
     }
 
     @Override
-    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+    public Flux<String> stream(String systemPrompt, String userPrompt) {
         try {
-            openAiChatClient.prompt()
+            return openAiChatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
                 .stream()
-                .content()
-                .doOnNext(onToken)
-                .subscribe();
+                .content();
         } catch (Exception e) {
             throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
         }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/client/OpenAiChatClient.java
@@ -2,6 +2,7 @@ package com.example.cs25service.domain.ai.client;
 
 import com.example.cs25service.domain.ai.exception.AiException;
 import com.example.cs25service.domain.ai.exception.AiExceptionCode;
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,21 @@ public class OpenAiChatClient implements AiChatClient {
     @Override
     public ChatClient raw() {
         return openAiChatClient;
+    }
+
+    @Override
+    public void stream(String systemPrompt, String userPrompt, Consumer<String> onToken) {
+        try {
+            openAiChatClient.prompt()
+                .system(systemPrompt)
+                .user(userPrompt)
+                .stream()
+                .content()
+                .doOnNext(onToken)
+                .subscribe();
+        } catch (Exception e) {
+            throw new AiException(AiExceptionCode.INTERNAL_SERVER_ERROR);
+        }
     }
 }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/test/TestDataInitializer.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/test/TestDataInitializer.java
@@ -12,8 +12,10 @@ import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,6 +26,9 @@ public class TestDataInitializer implements CommandLineRunner {
     private final UserRepository userRepository;
     private final QuizRepository quizRepository;
     private final UserQuizAnswerRepository answerRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Override
     @Transactional
@@ -65,5 +70,6 @@ public class TestDataInitializer implements CommandLineRunner {
                 .build());
         }
         answerRepository.saveAll(answers);
+        redisTemplate.delete("ai-feedback-dedup-set");
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- AI 응답을 문장 단위가 아닌 토큰 단위로 실시간 전송하는 스트리밍 기능을 구현했습니다.
- 기존 `AiChatClient.call()` 단일 응답 API에 `stream()` 메서드를 추가하고, 이를 SSE와 결합하여 응답 생성 과정을 보다 세밀하게 사용자에게 전달할 수 있게 개선했습니다.

---

## 🛠️ 변경 사항

###  AiChatClient 인터페이스

- `stream(String systemPrompt, String userPrompt): Flux<String>` 메서드 추가
- OpenAI, Claude, Fallback 각 Client에 stream 메서드 구현

###  AiFeedbackStreamProcessor

- 기존 `call()`로 한번에 응답 후 문장 분할 → Flux 기반 토큰 단위 스트리밍으로 전환
- `aiChatClient.stream()`을 구독하여 각 토큰마다 `send(emitter, token)` 전송
- 응답 버퍼(`StringBuilder feedbackBuffer`)를 사용하여 전체 피드백을 재조립 후 최종 저장 처리

###  TestDataInitializer

- `ai-feedback-dedup-set` Redis Key 초기화 추가
    - 부하 테스트 후 중복 키로 인해 재요청이 실패하는 문제 방지

---

## 🧩 트러블 슈팅

- **문제**: 응답이 한꺼번에 전달되어 사용자가 진행 상황을 체감할 수 없음
    - 해결: AI API의 Flux 응답을 SSE로 전달하여 실시간 응답 감각 제공
- **문제**: 부하 테스트 후 중복 방지 Set(`ai-feedback-dedup-set`)에 키가 남아 재시도 불가
    - 해결: TestDataInitializer에서 Redis Set 초기화 추가

---

## 📌 참고 사항

- 클라이언트는 SSE 수신 시 기존처럼 문장이 아닌 단어/문장 단위 토큰으로 전송되므로 프론트 단에서 이어 붙이는 로직 필요
- curl로 실행 시 나는 오류는 기능적 문제가 아닌 curl 실험 한정 현상임 버퍼링/스트림 완료 감지 차이로 자주 발생하는 것으로 부수적인 현상임

---

closed #189