### PR TITLE
Chore: 메일 템플릿을 인라인 스타일과 테이블 기반 레이아웃으로 수정

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/SesMailService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/SesMailService.java
@@ -3,9 +3,7 @@ package com.example.cs25batch.batch.service;
 import com.example.cs25batch.util.MailLinkGenerator;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -30,6 +28,7 @@ public class SesMailService {
         context.setVariable("toEmail", subscription.getEmail());
         context.setVariable("question", quiz.getQuestion());
         context.setVariable("quizLink", MailLinkGenerator.generateQuizLink(subscription.getSerialId(), quiz.getSerialId()));
+        context.setVariable("subscriptionSettings", MailLinkGenerator.generateSubscriptionSettings(subscription.getSerialId()));
         String htmlContent = templateEngine.process("mail-template", context);
 
         //수신인

--- a/cs25-batch/src/main/java/com/example/cs25batch/util/MailLinkGenerator.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/util/MailLinkGenerator.java
@@ -1,9 +1,13 @@
 package com.example.cs25batch.util;
 
 public class MailLinkGenerator {
-    private static final String DOMAIN = "https://cs25.co.kr/todayQuiz";
+    private static final String DOMAIN = "https://cs25.co.kr";
 
     public static String generateQuizLink(String subscriptionId, String quizId) {
-        return String.format("%s?subscriptionId=%s&quizId=%s", DOMAIN, subscriptionId, quizId);
+        return String.format("%s/todayQuiz?subscriptionId=%s&quizId=%s", DOMAIN, subscriptionId, quizId);
+    }
+
+    public static String generateSubscriptionSettings(String subscriptionId) {
+        return String.format("%s/subscriptions/%s", DOMAIN, subscriptionId);
     }
 }

--- a/cs25-batch/src/main/resources/templates/mail-template.html
+++ b/cs25-batch/src/main/resources/templates/mail-template.html
@@ -1,248 +1,118 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CS25 - 오늘의 CS 문제</title>
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      background-color: #f5f5f5;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 20px;
-    }
-
-    .email-container {
-      width: 100%;
-      max-width: 600px;
-      background-color: white;
-      border-radius: 16px;
-      overflow: hidden;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    }
-
-    .email-header {
-      background: linear-gradient(135deg, #5B8DEF 0%, #4A7FEB 100%);
-      color: white;
-      padding: 40px;
-      text-align: center;
-    }
-
-    .email-header h1 {
-      font-size: 36px;
-      font-weight: 700;
-      margin-bottom: 16px;
-    }
-
-    .email-header h2 {
-      font-size: 24px;
-      font-weight: 500;
-      margin-bottom: 8px;
-    }
-
-    .email-header p {
-      font-size: 16px;
-      opacity: 0.9;
-    }
-
-    .email-body {
-      padding: 60px 40px;
-      text-align: center;
-    }
-
-    .icon-circle {
-      width: 100px;
-      height: 100px;
-      background-color: #E8F0FE;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 0 auto 32px;
-    }
-
-    .icon-circle svg {
-      width: 50px;
-      height: 50px;
-      color: #5B8DEF;
-    }
-
-    .email-body h3 {
-      font-size: 28px;
-      font-weight: 700;
-      color: #1a1a1a;
-      margin-bottom: 24px;
-    }
-
-    .email-body p {
-      font-size: 16px;
-      color: #666;
-      line-height: 1.6;
-      margin-bottom: 40px;
-    }
-
-    .quiz-button {
-      display: inline-block;
-      background: linear-gradient(135deg, #5B8DEF 0%, #4A7FEB 100%);
-      color: white;
-      font-size: 18px;
-      font-weight: 600;
-      padding: 16px 48px;
-      border-radius: 50px;
-      text-decoration: none;
-      transition: all 0.3s ease;
-      box-shadow: 0 4px 15px rgba(91, 141, 239, 0.3);
-    }
-
-    .quiz-button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(91, 141, 239, 0.4);
-    }
-
-    .quiz-button span {
-      margin-right: 8px;
-    }
-
-    .footer-section {
-      background-color: #f8f9fa;
-      padding: 40px;
-      text-align: center;
-      border-top: 1px solid #e9ecef;
-    }
-
-    .footer-title {
-      font-size: 20px;
-      font-weight: 600;
-      color: #1a1a1a;
-      margin-bottom: 20px;
-    }
-
-    .tab-container {
-      display: flex;
-      justify-content: center;
-      gap: 8px;
-      margin-bottom: 40px;
-    }
-
-    .tab {
-      padding: 8px 24px;
-      border-radius: 20px;
-      font-size: 16px;
-      font-weight: 500;
-      border: none;
-      cursor: pointer;
-      transition: all 0.3s ease;
-    }
-
-    .tab.active {
-      background-color: #E8F0FE;
-      color: #5B8DEF;
-    }
-
-    .tab.inactive {
-      background-color: transparent;
-      color: #666;
-    }
-
-    .settings-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 32px;
-      background-color: #f0f2f5;
-      color: #495057;
-      border: none;
-      border-radius: 8px;
-      font-size: 16px;
-      font-weight: 500;
-      cursor: pointer;
-      transition: all 0.3s ease;
-    }
-
-    .settings-button:hover {
-      background-color: #e9ecef;
-    }
-
-    .footer-info {
-      margin-top: 40px;
-      padding-top: 24px;
-      border-top: 1px solid #e9ecef;
-    }
-
-    .footer-info p {
-      color: #666;
-      font-size: 14px;
-      line-height: 1.5;
-    }
-
-    .footer-info .rocket {
-      font-size: 20px;
-      margin-left: 4px;
-    }
-  </style>
 </head>
-<body>
-<div class="email-container">
-  <!-- Email Header -->
-  <div class="email-header">
-    <h1>CS 25</h1>
-    <h2>오늘의 CS 문제</h2>
-    <p>AI가 준비한 맞춤형 문제를 확인하세요</p>
-  </div>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f5f5f5; min-height: 100vh;">
 
-  <!-- Email Body -->
-  <div class="email-body">
-    <div class="icon-circle">
-      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-      </svg>
-    </div>
+<!-- Main Container Table -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="min-height: 100vh; background-color: #f5f5f5;">
+  <tr>
+    <td align="center" valign="middle" style="padding: 20px;">
 
-    <h3>오늘의 문제를 풀어보세요!</h3>
+      <!-- Email Container -->
+      <table width="600" cellpadding="0" cellspacing="0" border="0" style="max-width: 600px; background-color: white; border-radius: 16px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); overflow: hidden;">
 
-    <p>
-      안녕하세요! CS25에서 오늘의 맞춤형 CS 문제를 보내드립니다.<br>
-      AI가 생성한 문제와 상세한 해설로 CS 지식을 향상시켜보세요.
-    </p>
+        <!-- Email Header -->
+        <tr>
+          <td style="background: linear-gradient(135deg, #5B8DEF 0%, #4A7FEB 100%); color: white; padding: 40px; text-align: center;">
+            <h1 style="font-size: 36px; font-weight: 700; margin: 0 0 16px;">CS25</h1>
+            <h2 style="font-size: 24px; font-weight: 500; margin: 0 0 8px;">오늘의 CS 문제</h2>
+            <p style="margin: 0; font-size: 16px; opacity: 0.9;">AI가 준비한 맞춤형 문제를 확인하세요!</p>
+          </td>
+        </tr>
 
-    <div
-        style="background-color: #f9f9f9; border: 2px solid #4a90e2; border-radius: 8px; padding: 20px; margin: 15px 0; color: #222222; font-size: 16px; line-height: 1.6;">
-      <span th:text="${question}">여기에 문제 내용이 들어갑니다.</span>
-    </div>
+        <!-- Email Body -->
+        <tr>
+          <td style="background-color: white; padding: 60px 40px; text-align: center;">
 
-    <a th:href="${quizLink}" class="quiz-button">
-      <span>🚀</span> 문제 풀러 가기
-    </a>
-  </div>
+            <!-- Icon Circle -->
+            <table width="100" cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto 32px auto;">
+              <tr>
+                <td style="width: 100px; height: 100px; background-color: #E8F0FE; border-radius: 50%; text-align: center; vertical-align: middle;">
+                  <svg width="50" height="50" fill="none" stroke="#5B8DEF" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                  </svg>
+                </td>
+              </tr>
+            </table>
 
-  <!-- Footer Section -->
-  <div class="footer-section">
-    <button class="settings-button">
-      <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-        <path fill-rule="evenodd"
-              d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
-              clip-rule="evenodd"></path>
-      </svg>
-      구독 설정
-    </button>
+            <h3 style="font-size: 28px; font-weight: 700; color: #1a1a1a; margin: 0 0 24px;">오늘의 문제를 풀어보세요!</h3>
 
-    <div class="footer-info">
-      <p>
-        이 메일은 <span th:text="${toEmail}">example@email.com</span> 계정으로 발송되었습니다.<br/>
-      </p>
-      <p>매일 새로운 CS 지식으로 성장하는 개발자가 되어보세요! <span class="rocket">🚀</span></p>
-    </div>
-  </div>
-</div>
+            <p style="font-size: 16px; color: #666; line-height: 1.6; margin: 0 0 40px;">
+              안녕하세요! CS25에서 오늘의 맞춤형 CS 문제를 보내드립니다.<br>
+              AI가 생성한 문제와 상세한 해설로 CS 지식을 향상시켜보세요.
+            </p>
+
+            <!-- Question Box -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 15px 0;">
+              <tr>
+                <td style="background-color: #f9f9f9; border: 2px solid #4a90e2; border-radius: 8px; padding: 20px; color: #222222; font-size: 16px; line-height: 1.6;">
+                  <span th:text="${question}">여기에 문제 내용이 들어갑니다.</span>
+                </td>
+              </tr>
+            </table>
+
+            <!-- Quiz Button -->
+            <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto;">
+              <tr>
+                <td style="background: linear-gradient(135deg, #5B8DEF 0%, #4A7FEB 100%); border-radius: 50px; box-shadow: 0 4px 15px rgba(91, 141, 239, 0.3);">
+                  <a th:href="${quizLink}" style="display: inline-block; color: white; font-size: 18px; font-weight: 600; padding: 16px 48px; text-decoration: none;">
+                    문제 풀러 가기
+                  </a>
+                </td>
+              </tr>
+            </table>
+
+          </td>
+        </tr>
+
+        <!-- Footer Section -->
+        <tr>
+          <td style="background-color: #f8f9fa; padding: 40px; text-align: center; border-top: 1px solid #e9ecef;">
+            <!-- Settings Button -->
+            <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto 40px auto;">
+              <tr>
+                <td style="background-color: #f0f2f5; border-radius: 8px; padding: 12px 32px;">
+                    <a th:href="${subscriptionSettings}">
+                      <span style="color: #495057; font-size: 16px; font-weight: 500; display: inline-flex; align-items: center; gap: 8px;">
+                        <svg width="20" height="20" viewBox="0 0 20 20" fill="#495057">
+                          <path fill-rule="evenodd"
+                                d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+                                clip-rule="evenodd"></path>
+                        </svg>
+                        구독 설정
+                      </span>
+                    </a>
+                </td>
+              </tr>
+            </table>
+
+            <!-- Footer Info -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top: 40px; padding-top: 24px; border-top: 1px solid #e9ecef;">
+              <tr>
+                <td style="text-align: center;">
+                  <p style="color: #666; font-size: 14px; line-height: 1.5; margin: 0 0 8px;">
+                    이 메일은 <span th:text="${toEmail}">example@email.com</span> 계정으로 발송되었습니다.
+                  </p>
+                  <p style="margin: 0; color: #666; font-size: 14px; line-height: 1.5;">
+                    매일 새로운 CS 지식으로 성장하는 개발자가 되어보세요! <span style="font-size: 20px;">🚀</span>
+                  </p>
+                </td>
+              </tr>
+            </table>
+
+          </td>
+        </tr>
+
+      </table>
+
+    </td>
+  </tr>
+</table>
+
 </body>
 </html>


### PR DESCRIPTION
## 🔎 작업 내용

- 메일 템플릿을 인라인 스타일과 테이블 기반의 레이아웃으로 수정
- 메일 템플릿에 구독설정 링크를 추가
- 구독 설정 링크 생성 메서드 추가

---

## 📌 참고 사항

- 구글메일에선 깨지지 않는데, 네이버 메일에서 디자인이 깨지는 현상 발생
   -  네이버 메일이 지원하지 않기 때문!
   - 네이버 외에도 오래된 메일 클라이언트에선 디자인이 깨질 수 있음
   - [네이버 이메일 컨텐츠가 깨지는 경우](https://www.thewordcracker.com/intermediate/%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A9%94%EC%9D%BC%EB%A1%9C-%EB%B3%B4%EB%82%B8-%EC%9D%B4%EB%A9%94%EC%9D%BC%EC%9D%98-%EB%A0%88%EC%9D%B4%EC%95%84%EC%9B%83%EC%9D%B4-%EA%B9%A8%EC%A7%80%EB%8A%94-%EA%B2%BD/)

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인
