### PR TITLE
Chore: 문제 정답제출 시 발생하는 오류 수정

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/config/SecurityConfig.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/config/SecurityConfig.java
@@ -81,7 +81,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/quiz-categories/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PUT, "/quiz-categories/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.DELETE, "/quiz-categories/**").hasRole("ADMIN")
-                .requestMatchers(HttpMethod.POST, "/quizzes/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.DELETE, "/quizzes/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST, "/crawlers/github/**").hasRole("ADMIN")
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -21,7 +21,7 @@ public class UserQuizAnswerController {
     //정답 제출
     @PostMapping("/{quizId}")
     public ApiResponse<Long> answerSubmit(
-        @PathVariable("quizId") Long quizId,
+        @PathVariable("quizId") String quizId,
         @RequestBody UserQuizAnswerRequestDto requestDto
     ) {
         return new ApiResponse<>(200, userQuizAnswerService.answerSubmit(quizId, requestDto));

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
@@ -35,6 +35,7 @@ public class UserQuizAnswerService {
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
 
+    @Transactional
     public Long answerSubmit(String quizId, UserQuizAnswerRequestDto requestDto) {
 
         // 구독 정보 조회

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
@@ -1,18 +1,14 @@
 package com.example.cs25service.domain.userQuizAnswer.service;
 
 import com.example.cs25entity.domain.quiz.entity.Quiz;
-import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
-import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.exception.SubscriptionException;
 import com.example.cs25entity.domain.subscription.exception.SubscriptionExceptionCode;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
 import com.example.cs25entity.domain.user.entity.User;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
 import com.example.cs25entity.domain.userQuizAnswer.dto.UserAnswerDto;
 import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
@@ -21,7 +17,6 @@ import com.example.cs25entity.domain.userQuizAnswer.exception.UserQuizAnswerExce
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.userQuizAnswer.dto.*;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,9 +34,8 @@ public class UserQuizAnswerService {
     private final QuizRepository quizRepository;
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
-    private final QuizCategoryRepository quizCategoryRepository;
 
-    public Long answerSubmit(Long quizId, UserQuizAnswerRequestDto requestDto) {
+    public Long answerSubmit(String quizId, UserQuizAnswerRequestDto requestDto) {
 
         // 구독 정보 조회
         Subscription subscription = subscriptionRepository.findBySerialId(
@@ -49,19 +43,19 @@ public class UserQuizAnswerService {
             .orElseThrow(() -> new SubscriptionException(
                 SubscriptionExceptionCode.NOT_FOUND_SUBSCRIPTION_ERROR));
 
+        // 퀴즈 조회
+        Quiz quiz = quizRepository.findBySerialId(quizId)
+            .orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
+
         // 중복 답변 제출 막음
-        boolean isDuplicate = userQuizAnswerRepository.existsByQuizIdAndSubscriptionId(quizId,
-            subscription.getId());
+        boolean isDuplicate = userQuizAnswerRepository
+            .existsByQuizIdAndSubscriptionId(quiz.getId(), subscription.getId());
         if (isDuplicate) {
             throw new UserQuizAnswerException(UserQuizAnswerExceptionCode.DUPLICATED_ANSWER);
         }
 
         // 유저 정보 조회
         User user = userRepository.findBySubscription(subscription).orElse(null);
-
-        // 퀴즈 조회
-        Quiz quiz = quizRepository.findById(quizId)
-            .orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
 
         UserQuizAnswer answer = userQuizAnswerRepository.save(
             UserQuizAnswer.builder()


### PR DESCRIPTION


## 🔎 작업 내용

- 문제 제출 POST 요청 시, ADMIN 권한이 있어야 되는 부분 수정
- 문제 제출 시, `quizId` 파라미터 타입을 Long -> String 으로 수정

---

## 🧯 해결해야 할 문제

- `userQuizAnswer` 테스트 코드 수정이 필요함

---


### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 퀴즈 제출 시 quizId 경로 변수 타입이 Long에서 String으로 변경되어 다양한 형식의 ID를 지원합니다.

* **기타**
  * "/quizzes/**" 경로에 대한 POST 요청 권한 제한이 완화되어, ADMIN 역할이 아닌 사용자도 접근할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->