### PR TITLE
Refactor/205: 문장 단위 혹은 단어 단위 테스트용 SSE 리팩토링

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
@@ -2,13 +2,11 @@ package com.example.cs25service.domain.ai.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
-import com.example.cs25service.domain.ai.dto.response.AiFeedbackResponse;
 import com.example.cs25service.domain.ai.service.AiFeedbackQueueService;
 import com.example.cs25service.domain.ai.service.AiQuestionGeneratorService;
 import com.example.cs25service.domain.ai.service.AiService;
 import com.example.cs25service.domain.ai.service.FileLoaderService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,13 +23,23 @@ public class AiController {
     private final FileLoaderService fileLoaderService;
     private final AiFeedbackQueueService aiFeedbackQueueService;
 
-    @GetMapping("/{answerId}/feedback")
-    public SseEmitter streamFeedback(@PathVariable Long answerId) {
+    @GetMapping("/answers/{answerId}/feedback-word")
+    public SseEmitter streamWordFeedback(@PathVariable Long answerId) {
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        aiFeedbackQueueService.enqueue(answerId, emitter);
+        aiFeedbackQueueService.enqueue(answerId, emitter, "word");
+        return emitter;
+    }
+
+    @GetMapping("/answers/{answerId}/feedback-sentence")
+    public SseEmitter streamSentenceFeedback(@PathVariable Long answerId) {
+        SseEmitter emitter = new SseEmitter(60_000L);
+        emitter.onTimeout(emitter::complete);
+        emitter.onError(emitter::completeWithError);
+
+        aiFeedbackQueueService.enqueue(answerId, emitter, "sentence");
         return emitter;
     }
 
@@ -47,4 +55,6 @@ public class AiController {
         fileLoaderService.loadAndSaveFiles(basePath + dirName);
         return "파일 적재 완료!";
     }
+
+
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
@@ -2,11 +2,8 @@ package com.example.cs25service.domain.ai.service;
 
 import com.example.cs25service.domain.ai.config.RedisStreamConfig;
 import com.example.cs25service.domain.ai.queue.EmitterRegistry;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,25 +15,33 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class AiFeedbackQueueService {
 
+    public static final String DEDUPLICATION_SET_KEY = "ai-feedback-dedup-set";
     private final EmitterRegistry emitterRegistry;
     private final RedisTemplate<String, Object> redisTemplate;
-    public static final String DEDUPLICATION_SET_KEY = "ai-feedback-dedup-set";
 
-    public void enqueue(Long answerId, SseEmitter emitter) {
+    public void enqueue(Long answerId, SseEmitter emitter, String mode) {
         try {
-            // 중복 체크 (이미 등록된 경우 enqueue 하지 않음)
-            Long added = redisTemplate.opsForSet().add(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
+            // Redis Set을 통한 중복 체크
+            Long added = redisTemplate.opsForSet()
+                .add(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
             if (added == null || added == 0) {
                 log.info("Duplicate enqueue prevented for answerId {}", answerId);
+                completeWithError(emitter, new IllegalStateException("이미 처리중인 요청입니다."));
                 return;
             }
 
             emitterRegistry.register(answerId, emitter);
-            Map<String, Object> data = Map.of("answerId", answerId);
-            redisTemplate.opsForStream().add(RedisStreamConfig.STREAM_KEY, data);
+
+            Map<String, Object> message = new HashMap<>();
+            message.put("answerId", answerId);
+            message.put("mode", mode); // word/sentence 모드 구분 추가
+
+            redisTemplate.opsForStream().add(RedisStreamConfig.STREAM_KEY, message);
+
         } catch (Exception e) {
             emitterRegistry.remove(answerId);
-            redisTemplate.opsForSet().remove(DEDUPLICATION_SET_KEY, answerId); // 실패 시 롤백
+            redisTemplate.opsForSet()
+                .remove(DEDUPLICATION_SET_KEY, String.valueOf(answerId)); // 실패 시 롤백
             completeWithError(emitter, e);
         }
     }
@@ -48,5 +53,4 @@ public class AiFeedbackQueueService {
         }
         emitter.completeWithError(e);
     }
-
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -115,8 +115,7 @@ public class AiFeedbackStreamProcessor {
                 send(emitter, buffer.toString());
             }
 
-            String feedback =
-                answer.getAiFeedback() != null ? answer.getAiFeedback() : buffer.toString();
+            String feedback = buffer.toString();
             boolean isCorrect = feedback.startsWith("정답");
 
             User user = answer.getUser();

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -1,11 +1,9 @@
 package com.example.cs25service.domain.ai.service;
 
-import com.example.cs25entity.domain.quiz.repository.QuizRepository;
-import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.user.entity.User;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.ai.client.AiChatClient;
 import com.example.cs25service.domain.ai.exception.AiException;
@@ -28,14 +26,10 @@ public class AiFeedbackStreamProcessor {
     private final AiChatClient aiChatClient;
 
     @Transactional
-    public void stream(Long answerId, SseEmitter emitter) {
+    public void streamWord(Long answerId, SseEmitter emitter) {
         try {
-            var answer = userQuizAnswerRepository.findById(answerId)
-                .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
-
-            if (answer.getAiFeedback() != null) {
-                emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
-                emitter.complete();
+            var answer = prepare(answerId, emitter);
+            if (answer == null) {
                 return;
             }
 
@@ -46,32 +40,98 @@ public class AiFeedbackStreamProcessor {
 
             send(emitter, "AI 응답 대기 중...");
 
-            StringBuilder feedbackBuffer = new StringBuilder();
+            StringBuilder wordBuffer = new StringBuilder();
 
             aiChatClient.stream(systemPrompt, userPrompt)
                 .doOnNext(token -> {
-                    send(emitter, token);
-                    feedbackBuffer.append(token);
-                })
-                .doOnComplete(() -> {
-                    String feedback = feedbackBuffer.toString();
-                    boolean isCorrect = feedback.startsWith("정답");
-
-                    User user = answer.getUser();
-                    if(user != null){
-                        double score = isCorrect ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp()) : user.getScore() + 1;
-                        user.updateScore(score);
+                    wordBuffer.append(token);
+                    if (token.equals(" ") || token.matches("[.,!?]")) {
+                        send(emitter, wordBuffer.toString());
+                        wordBuffer.setLength(0);
                     }
-
-                    answer.updateIsCorrect(isCorrect);
-                    answer.updateAiFeedback(feedback);
-                    userQuizAnswerRepository.save(answer);
-
-                    emitter.complete();
                 })
+                .doOnComplete(() -> finalizeFeedback(answer, quiz, wordBuffer, emitter))
                 .doOnError(emitter::completeWithError)
                 .subscribe();
 
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+    }
+
+    @Transactional
+    public void streamSentence(Long answerId, SseEmitter emitter) {
+        try {
+            var answer = prepare(answerId, emitter);
+            if (answer == null) {
+                return;
+            }
+
+            var quiz = answer.getQuiz();
+            var docs = ragService.searchRelevant(quiz.getQuestion(), 3, 0.3);
+            String userPrompt = promptProvider.getFeedbackUser(quiz, answer, docs);
+            String systemPrompt = promptProvider.getFeedbackSystem();
+
+            send(emitter, "AI 응답 대기 중...");
+
+            StringBuilder sentenceBuffer = new StringBuilder();
+
+            aiChatClient.stream(systemPrompt, userPrompt)
+                .doOnNext(token -> {
+                    sentenceBuffer.append(token);
+                    if (token.matches("[.!?]")) {
+                        send(emitter, sentenceBuffer.toString());
+                        sentenceBuffer.setLength(0);
+                    }
+                })
+                .doOnComplete(() -> finalizeFeedback(answer, quiz, sentenceBuffer, emitter))
+                .doOnError(emitter::completeWithError)
+                .subscribe();
+
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+    }
+
+    private UserQuizAnswer prepare(Long answerId, SseEmitter emitter) throws IOException {
+        emitter.onTimeout(emitter::complete);
+        emitter.onError(emitter::completeWithError);
+
+        var answer = userQuizAnswerRepository.findById(answerId)
+            .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
+
+        if (answer.getAiFeedback() != null) {
+            emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
+            emitter.complete();
+            return null;
+        }
+        return answer;
+    }
+
+    private void finalizeFeedback(UserQuizAnswer answer, Quiz quiz, StringBuilder buffer,
+        SseEmitter emitter) {
+        try {
+            if (buffer.length() > 0) {
+                send(emitter, buffer.toString());
+            }
+
+            String feedback =
+                answer.getAiFeedback() != null ? answer.getAiFeedback() : buffer.toString();
+            boolean isCorrect = feedback.startsWith("정답");
+
+            User user = answer.getUser();
+            if (user != null) {
+                double score = isCorrect
+                    ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp())
+                    : user.getScore() + 1;
+                user.updateScore(score);
+            }
+
+            answer.updateIsCorrect(isCorrect);
+            answer.updateAiFeedback(feedback);
+            userQuizAnswerRepository.save(answer);
+
+            emitter.complete();
         } catch (Exception e) {
             emitter.completeWithError(e);
         }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
@@ -3,17 +3,13 @@ package com.example.cs25service.domain.ai.service;
 import com.example.cs25entity.domain.quiz.repository.QuizRepository;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
 import com.example.cs25entity.domain.user.entity.User;
-import com.example.cs25entity.domain.user.exception.UserException;
-import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.ai.client.AiChatClient;
-import com.example.cs25service.domain.ai.dto.request.FeedbackRequest;
 import com.example.cs25service.domain.ai.dto.response.AiFeedbackResponse;
 import com.example.cs25service.domain.ai.exception.AiException;
 import com.example.cs25service.domain.ai.exception.AiExceptionCode;
 import com.example.cs25service.domain.ai.prompt.AiPromptProvider;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -52,8 +48,10 @@ public class AiService {
         boolean isCorrect = feedback.startsWith("정답");
 
         User user = answer.getUser();
-        if(user != null){
-            double score = isCorrect ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp()) : user.getScore() + 1;
+        if (user != null) {
+            double score =
+                isCorrect ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp())
+                    : user.getScore() + 1;
             user.updateScore(score);
         }
 
@@ -69,12 +67,12 @@ public class AiService {
             .build();
     }
 
-    public SseEmitter streamFeedback(Long answerId) {
+    public SseEmitter streamFeedback(Long answerId, String mode) {
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        feedbackQueueService.enqueue(answerId, emitter);
+        feedbackQueueService.enqueue(answerId, emitter, mode);
         return emitter;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- AI 피드백 SSE 응답에 **word/sentence 모드별 스트리밍 기능**을 구현했습니다.
- 사용자 요청에 따라 한 단어 단위(word) 또는 한 문장 단위(sentence)로 AI 응답을 전송할 수 있도록 API와 내부 로직을 리팩토링했습니다.

## 📌 참고 사항

- 재사용 메서드로 prepare()이랑 finalizeFeedback() 분리하면서 DB 적합성 문제가 생길 수 있으나 테스트용이기 때문에 테스트 후 원래 구조로 변경하면 문제 해결 - 코드레빗이 경고하기 때문에 참고하세요.
- 나머지 관련 코드레빗 경고도 어처피 추후 단일 stream()구조로 다시 변경할 때 모두 해결될 예정

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 피드백 스트리밍 엔드포인트가 단어 단위(/answers/{answerId}/feedback-word)와 문장 단위(/answers/{answerId}/feedback-sentence)로 분리되어, 사용자가 원하는 방식으로 AI 피드백을 실시간으로 받을 수 있습니다.

* **버그 수정**
  * 중복 요청 시 명확한 오류 메시지가 반환되어, 이미 처리 중인 요청에 대한 혼동이 줄어듭니다.
  * 스트리밍 모드 정보가 누락되거나 알 수 없는 경우 적절한 오류 처리 및 로깅이 추가되었습니다.

* **리팩터링**
  * 피드백 처리 및 스트리밍 로직이 구조적으로 개선되어 안정성과 유지보수성이 향상되었습니다.
  * 피드백 스트리밍 준비 및 완료 과정이 모듈화되어 코드 가독성과 관리가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->