### PR TITLE
Feat/207 로그인 상태에서 구독 신청 구조 변경

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
@@ -11,7 +11,7 @@ public enum UserExceptionCode {
     EVENT_CRUD_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 값을 레디스에 읽기/저장 실패했으요"),
     LOCK_FAILED(false, HttpStatus.CONFLICT, "요청 시간 초과, 락 획득 실패"),
     INVALID_ROLE(false, HttpStatus.BAD_REQUEST, "역할 값이 잘못되었습니다."),
-    UNAUTHORIZE_ROLE(false, HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED_ROLE(false, HttpStatus.FORBIDDEN, "권한이 없습니다."),
     TOKEN_NOT_MATCHED(false, HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰 값이 아닙니다."),
     NOT_FOUND_USER(false, HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_SUBSCRIPTION(false, HttpStatus.NOT_FOUND, "해당 유저에게 구독 정보가 없습니다."),

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/repository/UserRepository.java
@@ -13,15 +13,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import javax.swing.text.html.Option;
-
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.subscription WHERE u.email = :email")
-    Optional<User> findUserWithSubscriptionByEmail(String email);
+//    @Query("SELECT u FROM User u LEFT JOIN FETCH u.subscription WHERE u.email = :email")
+//    Optional<User> findUserWithSubscriptionByEmail(String email);
 
     default void validateSocialJoinEmail(String email, SocialType socialType) {
         findByEmail(email).ifPresent(existingUser -> {

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
@@ -34,7 +34,7 @@ public class QuizAdminController {
         return new ApiResponse<>(200, quizAdminService.getAdminQuizDetails(page, size));
     }
 
-    //GET	관리자 문제  상세 조회	/admin/quizzes/{quizId}
+    //GET	관리자 문제 상세 조회	/admin/quizzes/{quizId}
     @GetMapping("/{quizId}")
     public ApiResponse<QuizDetailDto> getQuizDetail(
         @Positive @PathVariable(name = "quizId") Long quizId

--- a/cs25-service/src/main/java/com/example/cs25service/domain/mail/service/MailLogService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/mail/service/MailLogService.java
@@ -3,10 +3,10 @@ package com.example.cs25service.domain.mail.service;
 import com.example.cs25entity.domain.mail.dto.MailLogSearchDto;
 import com.example.cs25entity.domain.mail.entity.MailLog;
 import com.example.cs25entity.domain.mail.repository.MailLogRepository;
-import com.example.cs25service.domain.mail.dto.MailLogDetailResponse;
 import com.example.cs25entity.domain.user.entity.Role;
 import com.example.cs25entity.domain.user.exception.UserException;
 import com.example.cs25entity.domain.user.exception.UserExceptionCode;
+import com.example.cs25service.domain.mail.dto.MailLogDetailResponse;
 import com.example.cs25service.domain.mail.dto.MailLogResponse;
 import com.example.cs25service.domain.security.dto.AuthUser;
 import java.util.List;
@@ -24,11 +24,12 @@ public class MailLogService {
 
     //전체 로그 페이징 조회
     @Transactional(readOnly = true)
-    public Page<MailLogResponse> getMailLogs(AuthUser authUser, MailLogSearchDto condition, Pageable pageable) {
+    public Page<MailLogResponse> getMailLogs(AuthUser authUser, MailLogSearchDto condition,
+        Pageable pageable) {
 
         //유저 권한 확인
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        if (authUser.getRole() != Role.ADMIN) {
+            throw new UserException(UserExceptionCode.UNAUTHORIZED_ROLE);
         }
 
         //시작일과 종료일 모두 설정했을 때
@@ -46,8 +47,8 @@ public class MailLogService {
     @Transactional(readOnly = true)
     public MailLogDetailResponse getMailLog(AuthUser authUser, Long id) {
 
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        if (authUser.getRole() != Role.ADMIN) {
+            throw new UserException(UserExceptionCode.UNAUTHORIZED_ROLE);
         }
 
         MailLog mailLog = mailLogRepository.findByIdOrElseThrow(id);
@@ -57,8 +58,8 @@ public class MailLogService {
     @Transactional
     public void deleteMailLogs(AuthUser authUser, List<Long> ids) {
 
-        if(authUser.getRole() != Role.ADMIN){
-            throw new UserException(UserExceptionCode.UNAUTHORIZE_ROLE);
+        if (authUser.getRole() != Role.ADMIN) {
+            throw new UserException(UserExceptionCode.UNAUTHORIZED_ROLE);
         }
 
         if (ids == null || ids.isEmpty()) {

--- a/cs25-service/src/main/java/com/example/cs25service/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -23,7 +23,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final TokenService tokenService;
 
-    private boolean cookieSecure = true; // 배포시에는 true로 변경해야함
+    private final boolean cookieSecure = true; // 배포시에는 true로 변경해야함
 
     @Value("${FRONT_END_URI:http://localhost:5173}")
     private String frontEndUri;
@@ -41,7 +41,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         try {
             AuthUser authUser = (AuthUser) authentication.getPrincipal();
-            log.info("OAuth 로그인 성공: {}", authUser.getEmail());
+            log.info("OAuth 로그인 성공: {}", authUser.getName());
 
             TokenResponseDto tokenResponse = tokenService.generateAndSaveTokenPair(authUser);
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizCategoryController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizCategoryController.java
@@ -4,13 +4,10 @@ import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.quiz.dto.QuizCategoryRequestDto;
 import com.example.cs25service.domain.quiz.dto.QuizCategoryResponseDto;
 import com.example.cs25service.domain.quiz.service.QuizCategoryService;
-import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,8 +31,7 @@ public class QuizCategoryController {
 
     @PostMapping()
     public ApiResponse<String> createQuizCategory(
-        @Valid @RequestBody QuizCategoryRequestDto request,
-        @AuthenticationPrincipal AuthUser authUser
+        @Valid @RequestBody QuizCategoryRequestDto request
     ) {
         quizCategoryService.createQuizCategory(request);
         return new ApiResponse<>(200, "카테고리 등록 성공");
@@ -44,17 +40,16 @@ public class QuizCategoryController {
     @PutMapping("/{quizCategoryId}")
     public ApiResponse<QuizCategoryResponseDto> updateQuizCategory(
         @Valid @RequestBody QuizCategoryRequestDto request,
-        @NotNull @PathVariable Long quizCategoryId,
-        @AuthenticationPrincipal AuthUser authUser
-    ){
-        return new ApiResponse<>(200, quizCategoryService.updateQuizCategory(quizCategoryId, request));
+        @NotNull @PathVariable Long quizCategoryId
+    ) {
+        return new ApiResponse<>(200,
+            quizCategoryService.updateQuizCategory(quizCategoryId, request));
     }
 
     @DeleteMapping("/{quizCategoryId}")
     public ApiResponse<String> deleteQuizCategory(
-        @NotNull @PathVariable Long quizCategoryId,
-        @AuthenticationPrincipal AuthUser authUser
-    ){
+        @NotNull @PathVariable Long quizCategoryId
+    ) {
         quizCategoryService.deleteQuizCategory(quizCategoryId);
         return new ApiResponse<>(200, "카테고리가 삭제되었습니다.");
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/dto/AuthUser.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/dto/AuthUser.java
@@ -17,13 +17,11 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @RequiredArgsConstructor
 public class AuthUser implements OAuth2User {
 
-    private final String email;
     private final String name;
     private final String serialId;
     private final Role role;
 
     public AuthUser(User user) {
-        this.email = user.getEmail();
         this.name = user.getName();
         this.role = user.getRole();
         this.serialId = user.getSerialId();

--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -32,11 +32,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 if (jwtTokenProvider.validateToken(token)) {
                     String userId = jwtTokenProvider.getAuthorId(token);
-                    String email = jwtTokenProvider.getEmail(token);
+                    //String email = jwtTokenProvider.getEmail(token);
                     String nickname = jwtTokenProvider.getNickname(token);
                     Role role = jwtTokenProvider.getRole(token);
 
-                    AuthUser authUser = new AuthUser(email, nickname, userId, role);
+                    AuthUser authUser = new AuthUser(nickname, userId, role);
 
                     UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(authUser, null,

--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/provider/JwtTokenProvider.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/provider/JwtTokenProvider.java
@@ -38,22 +38,22 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateAccessToken(String userId, String email, String nickname, Role role) {
-        return createToken(userId, email, nickname, role, accessTokenExpiration);
+    public String generateAccessToken(String userId, String nickname, Role role) {
+        return createToken(userId, nickname, role, accessTokenExpiration);
     }
 
-    public String generateRefreshToken(String userId, String email, String nickname, Role role) {
-        return createToken(userId, email, nickname, role, refreshTokenExpiration);
+    public String generateRefreshToken(String userId, String nickname, Role role) {
+        return createToken(userId, nickname, role, refreshTokenExpiration);
     }
 
-    public TokenResponseDto generateTokenPair(String userId, String email, String nickname,
+    public TokenResponseDto generateTokenPair(String userId, String nickname,
         Role role) {
-        String accessToken = generateAccessToken(userId, email, nickname, role);
-        String refreshToken = generateRefreshToken(userId, email, nickname, role);
+        String accessToken = generateAccessToken(userId, nickname, role);
+        String refreshToken = generateRefreshToken(userId, nickname, role);
         return new TokenResponseDto(accessToken, refreshToken);
     }
 
-    private String createToken(String subject, String email, String nickname, Role role,
+    private String createToken(String subject, String nickname, Role role,
         long expirationMs) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
@@ -63,9 +63,9 @@ public class JwtTokenProvider {
             .issuedAt(now)
             .expiration(expiry);
 
-        if (email != null) {
-            builder.claim("email", email);
-        }
+//        if (email != null) {
+//            builder.claim("email", email);
+//        }
         if (nickname != null) {
             builder.claim("nickname", nickname);
         }
@@ -115,9 +115,9 @@ public class JwtTokenProvider {
         return parseClaims(token).getSubject();
     }
 
-    public String getEmail(String token) throws JwtAuthenticationException {
-        return parseClaims(token).get("email", String.class);
-    }
+//    public String getEmail(String token) throws JwtAuthenticationException {
+//        return parseClaims(token).get("email", String.class);
+//    }
 
     public String getNickname(String token) throws JwtAuthenticationException {
         return parseClaims(token).get("nickname", String.class);

--- a/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/service/TokenService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/security/jwt/service/TokenService.java
@@ -19,10 +19,10 @@ public class TokenService {
 
     public TokenResponseDto generateAndSaveTokenPair(AuthUser authUser) {
         String accessToken = jwtTokenProvider.generateAccessToken(
-            authUser.getSerialId(), authUser.getEmail(), authUser.getName(), authUser.getRole()
+            authUser.getSerialId(), authUser.getName(), authUser.getRole()
         );
         String refreshToken = jwtTokenProvider.generateRefreshToken(
-            authUser.getSerialId(), authUser.getEmail(), authUser.getName(), authUser.getRole()
+            authUser.getSerialId(), authUser.getName(), authUser.getRole()
         );
         refreshTokenService.save(authUser.getSerialId(), refreshToken,
             jwtTokenProvider.getRefreshTokenDuration());

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
@@ -68,7 +68,7 @@ public class SubscriptionService {
     /**
      * 구독정보를 생성하는 메서드
      *
-     * @param request 사용자를 통해 받은 생성할 구독 정보
+     * @param request  사용자를 통해 받은 생성할 구독 정보
      * @param authUser 로그인 정보
      * @return 구독 응답 DTO를 반환
      */
@@ -95,7 +95,7 @@ public class SubscriptionService {
                 LocalDate nowDate = LocalDate.now();
                 Subscription subscription = subscriptionRepository.save(
                     Subscription.builder()
-                        .email(user.getEmail())
+                        .email(request.getEmail())
                         .category(quizCategory)
                         .startDate(nowDate)
                         .endDate(nowDate.plusMonths(request.getPeriod().getMonths()))

--- a/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/subscription/service/SubscriptionService.java
@@ -87,7 +87,7 @@ public class SubscriptionService {
 
         // 로그인을 한 경우
         if (authUser != null) {
-            User user = userRepository.findUserWithSubscriptionByEmail(authUser.getEmail())
+            User user = userRepository.findBySerialId(authUser.getSerialId())
                 .orElseThrow(() -> new UserException(UserExceptionCode.NOT_FOUND_USER));
 
             // 구독 정보가 없는 경우

--- a/cs25-service/src/main/java/com/example/cs25service/domain/users/service/AuthService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/users/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
         String refreshToken = reissueRequestDto.getRefreshToken();
 
         String userId = jwtTokenProvider.getAuthorId(refreshToken);
-        String email = jwtTokenProvider.getEmail(refreshToken);
+        //String email = jwtTokenProvider.getEmail(refreshToken);
         String nickname = jwtTokenProvider.getNickname(refreshToken);
         Role role = jwtTokenProvider.getRole(refreshToken);
 
@@ -38,8 +38,7 @@ public class AuthService {
         }
 
         // 4. 새 토큰 발급
-        TokenResponseDto newToken = jwtTokenProvider.generateTokenPair(userId, email, nickname,
-            role);
+        TokenResponseDto newToken = jwtTokenProvider.generateTokenPair(userId, nickname, role);
 
         // 5. Redis 갱신
         refreshTokenService.save(userId, newToken.getRefreshToken(),

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
@@ -1,15 +1,12 @@
 package com.example.cs25service.domain.verification.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
-import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.verification.dto.VerificationIssueRequest;
 import com.example.cs25service.domain.verification.dto.VerificationVerifyRequest;
 import com.example.cs25service.domain.verification.service.VerificationPreprocessingService;
 import com.example.cs25service.domain.verification.service.VerificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,20 +20,11 @@ public class VerificationController {
     private final VerificationService verificationService;
     private final VerificationPreprocessingService preprocessingService;
 
-    //이메일 인증 전에 검사
-    @GetMapping()
-    public ApiResponse<String> isValidEmailCheck(
-        @Valid @RequestBody VerificationIssueRequest request,
-        @AuthenticationPrincipal AuthUser authUser
-    ) {
-        preprocessingService.isValidEmailCheck(request.getEmail(), authUser);
-        return new ApiResponse<>(200, "확인 완료");
-    }
-
-
     @PostMapping()
     public ApiResponse<String> issueVerificationCodeByEmail(
         @Valid @RequestBody VerificationIssueRequest request) {
+
+        preprocessingService.isValidEmailCheck(request.getEmail());
         verificationService.issue(request.getEmail());
         return new ApiResponse<>(200, "인증코드가 발급되었습니다.");
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
@@ -1,11 +1,15 @@
 package com.example.cs25service.domain.verification.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.verification.dto.VerificationIssueRequest;
 import com.example.cs25service.domain.verification.dto.VerificationVerifyRequest;
+import com.example.cs25service.domain.verification.service.VerificationPreprocessingService;
 import com.example.cs25service.domain.verification.service.VerificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +21,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class VerificationController {
 
     private final VerificationService verificationService;
+    private final VerificationPreprocessingService preprocessingService;
+
+    //이메일 인증 전에 검사
+    @GetMapping()
+    public ApiResponse<String> isValidEmailCheck(
+        @Valid @RequestBody VerificationIssueRequest request,
+        @AuthenticationPrincipal AuthUser authUser
+    ) {
+        preprocessingService.isValidEmailCheck(request.getEmail(), authUser);
+        return new ApiResponse<>(200, "확인 완료");
+    }
+
 
     @PostMapping()
     public ApiResponse<String> issueVerificationCodeByEmail(

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
@@ -1,0 +1,35 @@
+package com.example.cs25service.domain.verification.service;
+
+import com.example.cs25entity.domain.subscription.exception.SubscriptionException;
+import com.example.cs25entity.domain.subscription.exception.SubscriptionExceptionCode;
+import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
+import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.security.dto.AuthUser;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationPreprocessingService {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserRepository userRepository;
+
+    public void isValidEmailCheck(
+        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        AuthUser authUser) {
+
+        if (subscriptionRepository.existsByEmail(email)) {
+            throw new SubscriptionException(
+                SubscriptionExceptionCode.DUPLICATE_SUBSCRIPTION_EMAIL_ERROR);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new UserException(UserExceptionCode.EMAIL_DUPLICATION);
+        }
+    }
+}

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
@@ -6,7 +6,6 @@ import com.example.cs25entity.domain.subscription.repository.SubscriptionReposit
 import com.example.cs25entity.domain.user.exception.UserException;
 import com.example.cs25entity.domain.user.exception.UserExceptionCode;
 import com.example.cs25entity.domain.user.repository.UserRepository;
-import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +19,7 @@ public class VerificationPreprocessingService {
     private final UserRepository userRepository;
 
     public void isValidEmailCheck(
-        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
-        AuthUser authUser) {
+        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email) {
 
         if (subscriptionRepository.existsByEmail(email)) {
             throw new SubscriptionException(

--- a/cs25-service/src/test/java/com/example/cs25service/domain/mail/service/MailLogServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/mail/service/MailLogServiceTest.java
@@ -1,6 +1,10 @@
 package com.example.cs25service.domain.mail.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.example.cs25entity.domain.mail.dto.MailLogSearchDto;
 import com.example.cs25entity.domain.mail.entity.MailLog;
@@ -28,8 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MailLogServiceTest {
@@ -44,7 +46,7 @@ class MailLogServiceTest {
     private AuthUser authUser;
 
     @BeforeEach
-    public void setUp(){
+    public void setUp() {
         User user = User.builder()
             .email("test@test.com")
             .name("test")
@@ -81,7 +83,8 @@ class MailLogServiceTest {
         when(mailLogRepository.search(condition, pageable)).thenReturn(mockPage);
 
         //when
-        Page<MailLogResponse> result = mailLogService.getMailLogs(authUserAdmin, condition, pageable);
+        Page<MailLogResponse> result = mailLogService.getMailLogs(authUserAdmin, condition,
+            pageable);
 
         //then
         assertEquals(1, result.getContent().size());
@@ -102,8 +105,8 @@ class MailLogServiceTest {
             .build();
 
         MailLogSearchDto condition = MailLogSearchDto.builder()
-            .startDate(LocalDate.of(2025,7,1))
-            .endDate(LocalDate.of(2024, 7,1))
+            .startDate(LocalDate.of(2025, 7, 1))
+            .endDate(LocalDate.of(2024, 7, 1))
             .build();
 
         //when
@@ -125,7 +128,7 @@ class MailLogServiceTest {
             mailLogService.getMailLogs(authUser, condition, Pageable.ofSize(10)));
 
         //then
-        assertEquals(UserExceptionCode.UNAUTHORIZE_ROLE, ex.getErrorCode());
+        assertEquals(UserExceptionCode.UNAUTHORIZED_ROLE, ex.getErrorCode());
     }
 
     @Test
@@ -157,7 +160,7 @@ class MailLogServiceTest {
         UserException ex = assertThrows(UserException.class, () ->
             mailLogService.getMailLog(authUser, 1L));
 
-        assertEquals(UserExceptionCode.UNAUTHORIZE_ROLE, ex.getErrorCode());
+        assertEquals(UserExceptionCode.UNAUTHORIZED_ROLE, ex.getErrorCode());
     }
 
     @Test
@@ -187,6 +190,6 @@ class MailLogServiceTest {
         UserException ex = assertThrows(UserException.class, () ->
             mailLogService.deleteMailLogs(authUser, ids));
 
-        assertEquals(UserExceptionCode.UNAUTHORIZE_ROLE, ex.getErrorCode());
+        assertEquals(UserExceptionCode.UNAUTHORIZED_ROLE, ex.getErrorCode());
     }
 }

--- a/cs25-service/src/test/java/com/example/cs25service/domain/profile/service/ProfileServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/profile/service/ProfileServiceTest.java
@@ -122,14 +122,13 @@ class ProfileServiceTest {
             .build();
 
         authUser = AuthUser.builder()
-            .email("test@naver.com")
             .name("test")
             .role(Role.USER)
             .serialId(serialId)
             .build();
 
         user = User.builder()
-            .email(authUser.getEmail())
+            .email("test@naver.com")
             .name(authUser.getName())
             .role(authUser.getRole())
             .subscription(subscription)
@@ -233,7 +232,7 @@ class ProfileServiceTest {
         @BeforeEach
         void setUp() {
             user = User.builder()
-                .email(authUser.getEmail())
+                .email("test@naver.com")
                 .name(authUser.getName())
                 .role(authUser.getRole())
                 .subscription(subscription)

--- a/cs25-service/src/test/java/com/example/cs25service/domain/subscription/service/SubscriptionServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/subscription/service/SubscriptionServiceTest.java
@@ -1,25 +1,17 @@
 package com.example.cs25service.domain.subscription.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.lang.reflect.Field;
-import java.time.LocalDate;
-import java.util.EnumSet;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
 
 import com.example.cs25entity.domain.quiz.entity.QuizCategory;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
-import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
 import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
 import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
@@ -34,308 +26,320 @@ import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.subscription.dto.SubscriptionInfoDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
 import com.example.cs25service.domain.subscription.dto.SubscriptionResponseDto;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SubscriptionServiceTest {
 
-	@Mock
-	private SubscriptionRepository subscriptionRepository;
-	
-	@Mock
-	private SubscriptionHistoryRepository subscriptionHistoryRepository;
-	
-	@Mock
-	private QuizCategoryRepository quizCategoryRepository;
-	
-	@Mock
-	private UserRepository userRepository;
-	
-	@InjectMocks
-	private SubscriptionService subscriptionService;
-	
-	private QuizCategory quizCategory;
-	private Subscription subscription;
-	private User user;
-	private AuthUser authUser;
-	private SubscriptionRequestDto requestDto;
-	
-	@BeforeEach
-	void setUp() {
-		quizCategory = QuizCategory.builder()
-			.categoryType("BACKEND")
-			.build();
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
 
-		subscription = Subscription.builder()
-			.email("test@test.com")
-			.category(quizCategory)
-			.startDate(LocalDate.now())
-			.endDate(LocalDate.now().plusMonths(1))
-			.subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
-			.build();
+    @Mock
+    private SubscriptionHistoryRepository subscriptionHistoryRepository;
 
-		// 리플렉션을 이용하여 ID 값을 1L로 지정
-		try {
-			Field idField = Subscription.class.getDeclaredField("id");
-			idField.setAccessible(true);
-			idField.set(subscription, 1L);
-		} catch (Exception exception) {
-			// 예외처리
-		}
-			
-		user = User.builder()
-			.email("test@test.com")
-			.name("testuser")
-			.build();
-			
-		authUser = AuthUser.builder()
-			.email("test@test.com")
-			.name("testuser")
-			.build();
+    @Mock
+    private QuizCategoryRepository quizCategoryRepository;
 
-		requestDto = SubscriptionRequestDto.builder()
-			.category("BACKEND")
-			.email("test@test.com")
-			.period(SubscriptionPeriod.ONE_MONTH)
-			.days(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
-			.build();
-	}
-	
-	@Test
-	@DisplayName("구독 정보 조회 성공")
-	void getSubscription_success() {
-		// given
-		String subscriptionId = "id";
-		given(subscriptionRepository.findBySerialId(subscriptionId))
-			.willReturn(Optional.of(subscription));
-		
-		// when
-		SubscriptionInfoDto result = subscriptionService.getSubscription(subscriptionId);
-		
-		// then
-		assertEquals("BACKEND", result.getCategory());
-		assertEquals("test@test.com", result.getEmail());
-		assertTrue(result.isActive());
-		assertEquals(subscription.getStartDate(), result.getStartDate());
-		assertEquals(subscription.getEndDate(), result.getEndDate());
-	}
-	
-	@Test
-	@DisplayName("존재하지 않는 구독 ID로 조회 시 예외 발생")
-	void getSubscription_notFound() {
-		// given
-		String subscriptionId = "id";
-		given(subscriptionRepository.findBySerialId(subscriptionId))
-			.willReturn(Optional.empty());
-		
-		// when & then
-		assertThrows(QuizException.class, 
-			() -> subscriptionService.getSubscription(subscriptionId));
-	}
-	
-	@Test
-	@DisplayName("로그인 사용자 구독 생성 성공")
-	void createSubscription_withAuthUser_success() {
-		// given
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		given(userRepository.findUserWithSubscriptionByEmail("test@test.com"))
-			.willReturn(Optional.of(user));
-		given(subscriptionRepository.save(any(Subscription.class)))
-			.willAnswer(invocation -> {
-				Subscription savedSubscription = invocation.getArgument(0);
-				try {
-					Field idField = Subscription.class.getDeclaredField("id");
-					idField.setAccessible(true);
-					idField.set(savedSubscription, 1L);
-				} catch (Exception e) {
-					// 예외처리
-				}
-				return savedSubscription;
-			});
-		given(subscriptionHistoryRepository.save(any()))
-			.willReturn(null);
-		
-		// when
-		SubscriptionResponseDto result = subscriptionService.createSubscription(requestDto, authUser);
-		
-		// then
-		assertNotNull(result);
-		assertEquals("BACKEND", result.getCategory());
-		assertEquals(subscription.getStartDate(), result.getStartDate());
-		assertEquals(subscription.getEndDate(), result.getEndDate());
-	}
-	
-	@Test
-	@DisplayName("비로그인 사용자 구독 생성 성공")
-	void createSubscription_withoutAuthUser_success() {
-		// given
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		given(subscriptionRepository.existsByEmail("test@test.com"))
-			.willReturn(false);
-		given(subscriptionRepository.save(any(Subscription.class)))
-			.willAnswer(invocation -> {
-				Subscription savedSubscription = invocation.getArgument(0);
-				try {
-					Field idField = Subscription.class.getDeclaredField("id");
-					idField.setAccessible(true);
-					idField.set(savedSubscription, 1L);
-				} catch (Exception e) {
-					// 예외처리
-				}
-				return savedSubscription;
-			});
-		given(subscriptionHistoryRepository.save(any()))
-			.willReturn(null);
-		
-		// when
-		SubscriptionResponseDto result = subscriptionService.createSubscription(requestDto, null);
-		
-		// then
-		assertNotNull(result);
-		assertEquals("BACKEND", result.getCategory());
-		assertEquals(subscription.getStartDate(), result.getStartDate());
-		assertEquals(subscription.getEndDate(), result.getEndDate());
-	}
-	
-	@Test
-	@DisplayName("자식 카테고리로 구독 생성 시 예외 발생")
-	void createSubscription_childCategory_exception() {
-		// given
-		QuizCategory childCategory = QuizCategory.builder()
-			.categoryType("BACKEND")
-			.parent(quizCategory)
-			.build();
-			
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(childCategory);
-		
-		// when & then
-		QuizException ex = assertThrows(QuizException.class,
-			() -> subscriptionService.createSubscription(requestDto, authUser));
-		assertThat(ex.getMessage()).contains("대분류 카테고리가 필요합니다.");
-	}
-	
-	@Test
-	@DisplayName("이미 구독 중인 사용자의 중복 구독 생성 시 예외 발생")
-	void createSubscription_duplicateSubscription_exception() {
-		// given
-		User userWithSubscription = User.builder()
-			.email("test@test.com")
-			.name("testuser")
-			.subscription(subscription)
-			.build();
-			
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		given(userRepository.findUserWithSubscriptionByEmail("test@test.com"))
-			.willReturn(Optional.of(userWithSubscription));
-		
-		// when & then
-		SubscriptionException ex = assertThrows(SubscriptionException.class,
-			() -> subscriptionService.createSubscription(requestDto, authUser));
-		assertThat(ex.getMessage()).contains("이미 구독중인 이메일입니다.");
-	}
-	
-	@Test
-	@DisplayName("구독 정보 업데이트 성공")
-	void updateSubscription_success() {
-		// given
-		given(subscriptionRepository.findBySerialId("id"))
-			.willReturn(Optional.of(subscription));
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		
-		// when
-		assertDoesNotThrow(() -> subscriptionService.updateSubscription("id", requestDto));
-		
-		// then
-		verify(subscriptionHistoryRepository).save(any());
-	}
-	
-	@Test
-	@DisplayName("1년 초과 구독 기간 업데이트 시 예외 발생")
-	void updateSubscription_exceedsMaxPeriod_exception() {
-		// given
-		Subscription overSubscription = Subscription.builder()
-			.email("test@test.com")
-			.category(quizCategory)
-			.startDate(LocalDate.now())
-			.endDate(LocalDate.now().plusMonths(11)) // 이미 11개월
-			.subscriptionType(EnumSet.of(DayOfWeek.MONDAY))
-			.build();
-			
-		SubscriptionRequestDto overRequestDto = SubscriptionRequestDto.builder()
-			.category("BACKEND")
-			.period(SubscriptionPeriod.THREE_MONTHS) // 3개월 더 추가하면 1년 초과
-			.days(EnumSet.of(DayOfWeek.MONDAY))
-			.active(true)
-			.build();
-			
-		given(subscriptionRepository.findBySerialId("id"))
-			.willReturn(Optional.of(overSubscription));
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		
-		// when & then
-		SubscriptionException ex = assertThrows(SubscriptionException.class,
-			() -> subscriptionService.updateSubscription("id", overRequestDto));
-		assertThat(ex.getMessage()).contains("구독 시작일로부터 1년 이상 구독할 수 없습니다.");
-	}
-	
-	@Test
-	@DisplayName("구독 취소 성공")
-	void cancelSubscription_success() {
-		// given
-		given(subscriptionRepository.findBySerialId("id"))
-			.willReturn(Optional.of(subscription));
-		
-		// when
-		assertDoesNotThrow(() -> subscriptionService.cancelSubscription("id"));
-		
-		// then
-		verify(subscriptionHistoryRepository).save(any());
-	}
-	
-	@Test
-	@DisplayName("이메일 중복 체크 - 중복되지 않은 경우")
-	void checkEmail_noDuplicate_success() {
-		// given
-		String email = "123@123.com";
-		given(subscriptionRepository.existsByEmail(email))
-			.willReturn(false);
-		
-		// when & then
-		assertDoesNotThrow(() -> subscriptionService.checkEmail(email));
-	}
-	
-	@Test
-	@DisplayName("이메일 중복 체크 - 중복된 경우 예외 발생")
-	void checkEmail_duplicate_exception() {
-		// given
-		String email = "123@123.com";
-		given(subscriptionRepository.existsByEmail(email))
-			.willReturn(true);
-		
-		// when & then
-		SubscriptionException ex = assertThrows(SubscriptionException.class,
-			() -> subscriptionService.checkEmail(email));
-		assertThat(ex.getMessage()).contains("이미 구독중인 이메일입니다.");
+    @Mock
+    private UserRepository userRepository;
 
-	}
+    @InjectMocks
+    private SubscriptionService subscriptionService;
 
-	@Test
-	@DisplayName("존재하지 않는 사용자로 구독 생성 시 예외 발생")
-	void createSubscription_userNotFound_exception() {
-		// given
-		given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
-			.willReturn(quizCategory);
-		given(userRepository.findUserWithSubscriptionByEmail("test@test.com"))
-			.willReturn(Optional.empty());
-		
-		// when & then
-		UserException ex = assertThrows(UserException.class,
-			() -> subscriptionService.createSubscription(requestDto, authUser));
-		assertThat(ex.getMessage()).contains("해당 유저를 찾을 수 없습니다.");
-	}
+    private QuizCategory quizCategory;
+    private Subscription subscription;
+    private User user;
+    private AuthUser authUser;
+    private SubscriptionRequestDto requestDto;
+
+    @BeforeEach
+    void setUp() {
+        quizCategory = QuizCategory.builder()
+            .categoryType("BACKEND")
+            .build();
+
+        subscription = Subscription.builder()
+            .email("test@test.com")
+            .category(quizCategory)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusMonths(1))
+            .subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+            .build();
+
+        // 리플렉션을 이용하여 ID 값을 1L로 지정
+        try {
+            Field idField = Subscription.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(subscription, 1L);
+        } catch (Exception exception) {
+            // 예외처리
+        }
+
+        user = User.builder()
+            .email("test@test.com")
+            .name("testuser")
+            .build();
+
+        authUser = AuthUser.builder()
+            .name("testuser")
+            .serialId("user-serial-id")
+            .build();
+
+        requestDto = SubscriptionRequestDto.builder()
+            .category("BACKEND")
+            .email("test@test.com")
+            .period(SubscriptionPeriod.ONE_MONTH)
+            .days(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+            .build();
+    }
+
+    @Test
+    @DisplayName("구독 정보 조회 성공")
+    void getSubscription_success() {
+        // given
+        String subscriptionId = "id";
+        given(subscriptionRepository.findBySerialId(subscriptionId))
+            .willReturn(Optional.of(subscription));
+
+        // when
+        SubscriptionInfoDto result = subscriptionService.getSubscription(subscriptionId);
+
+        // then
+        assertEquals("BACKEND", result.getCategory());
+        assertEquals("test@test.com", result.getEmail());
+        assertTrue(result.isActive());
+        assertEquals(subscription.getStartDate(), result.getStartDate());
+        assertEquals(subscription.getEndDate(), result.getEndDate());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 구독 ID로 조회 시 예외 발생")
+    void getSubscription_notFound() {
+        // given
+        String subscriptionId = "id";
+        given(subscriptionRepository.findBySerialId(subscriptionId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(QuizException.class,
+            () -> subscriptionService.getSubscription(subscriptionId));
+    }
+
+    @Test
+    @DisplayName("로그인 사용자 구독 생성 성공")
+    void createSubscription_withAuthUser_success() {
+        // given
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+        given(userRepository.findBySerialId("user-serial-id"))
+            .willReturn(Optional.of(user));
+        given(subscriptionRepository.save(any(Subscription.class)))
+            .willAnswer(invocation -> {
+                Subscription savedSubscription = invocation.getArgument(0);
+                try {
+                    Field idField = Subscription.class.getDeclaredField("id");
+                    idField.setAccessible(true);
+                    idField.set(savedSubscription, 1L);
+                } catch (Exception e) {
+                    // 예외처리
+                }
+                return savedSubscription;
+            });
+        given(subscriptionHistoryRepository.save(any()))
+            .willReturn(null);
+
+        // when
+        SubscriptionResponseDto result = subscriptionService.createSubscription(requestDto,
+            authUser);
+
+        // then
+        assertNotNull(result);
+        assertEquals("BACKEND", result.getCategory());
+        assertEquals(subscription.getStartDate(), result.getStartDate());
+        assertEquals(subscription.getEndDate(), result.getEndDate());
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자 구독 생성 성공")
+    void createSubscription_withoutAuthUser_success() {
+        // given
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+        given(subscriptionRepository.existsByEmail("test@test.com"))
+            .willReturn(false);
+        given(subscriptionRepository.save(any(Subscription.class)))
+            .willAnswer(invocation -> {
+                Subscription savedSubscription = invocation.getArgument(0);
+                try {
+                    Field idField = Subscription.class.getDeclaredField("id");
+                    idField.setAccessible(true);
+                    idField.set(savedSubscription, 1L);
+                } catch (Exception e) {
+                    // 예외처리
+                }
+                return savedSubscription;
+            });
+        given(subscriptionHistoryRepository.save(any()))
+            .willReturn(null);
+
+        // when
+        SubscriptionResponseDto result = subscriptionService.createSubscription(requestDto, null);
+
+        // then
+        assertNotNull(result);
+        assertEquals("BACKEND", result.getCategory());
+        assertEquals(subscription.getStartDate(), result.getStartDate());
+        assertEquals(subscription.getEndDate(), result.getEndDate());
+    }
+
+    @Test
+    @DisplayName("자식 카테고리로 구독 생성 시 예외 발생")
+    void createSubscription_childCategory_exception() {
+        // given
+        QuizCategory childCategory = QuizCategory.builder()
+            .categoryType("BACKEND")
+            .parent(quizCategory)
+            .build();
+
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(childCategory);
+
+        // when & then
+        QuizException ex = assertThrows(QuizException.class,
+            () -> subscriptionService.createSubscription(requestDto, authUser));
+        assertThat(ex.getMessage()).contains("대분류 카테고리가 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("이미 구독 중인 사용자의 중복 구독 생성 시 예외 발생")
+    void createSubscription_duplicateSubscription_exception() {
+        // given
+        User userWithSubscription = User.builder()
+            .email("test@test.com")
+            .name("testuser")
+            .subscription(subscription)
+            .build();
+
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+        given(userRepository.findBySerialId("user-serial-id"))
+            .willReturn(Optional.of(userWithSubscription));
+
+        // when & then
+        SubscriptionException ex = assertThrows(SubscriptionException.class,
+            () -> subscriptionService.createSubscription(requestDto, authUser));
+        assertThat(ex.getMessage()).contains("이미 구독중인 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("구독 정보 업데이트 성공")
+    void updateSubscription_success() {
+        // given
+        given(subscriptionRepository.findBySerialId("id"))
+            .willReturn(Optional.of(subscription));
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+
+        // when
+        assertDoesNotThrow(() -> subscriptionService.updateSubscription("id", requestDto));
+
+        // then
+        verify(subscriptionHistoryRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("1년 초과 구독 기간 업데이트 시 예외 발생")
+    void updateSubscription_exceedsMaxPeriod_exception() {
+        // given
+        Subscription overSubscription = Subscription.builder()
+            .email("test@test.com")
+            .category(quizCategory)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusMonths(11)) // 이미 11개월
+            .subscriptionType(EnumSet.of(DayOfWeek.MONDAY))
+            .build();
+
+        SubscriptionRequestDto overRequestDto = SubscriptionRequestDto.builder()
+            .category("BACKEND")
+            .period(SubscriptionPeriod.THREE_MONTHS) // 3개월 더 추가하면 1년 초과
+            .days(EnumSet.of(DayOfWeek.MONDAY))
+            .active(true)
+            .build();
+
+        given(subscriptionRepository.findBySerialId("id"))
+            .willReturn(Optional.of(overSubscription));
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+
+        // when & then
+        SubscriptionException ex = assertThrows(SubscriptionException.class,
+            () -> subscriptionService.updateSubscription("id", overRequestDto));
+        assertThat(ex.getMessage()).contains("구독 시작일로부터 1년 이상 구독할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("구독 취소 성공")
+    void cancelSubscription_success() {
+        // given
+        given(subscriptionRepository.findBySerialId("id"))
+            .willReturn(Optional.of(subscription));
+
+        // when
+        assertDoesNotThrow(() -> subscriptionService.cancelSubscription("id"));
+
+        // then
+        verify(subscriptionHistoryRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복되지 않은 경우")
+    void checkEmail_noDuplicate_success() {
+        // given
+        String email = "123@123.com";
+        given(subscriptionRepository.existsByEmail(email))
+            .willReturn(false);
+
+        // when & then
+        assertDoesNotThrow(() -> subscriptionService.checkEmail(email));
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복된 경우 예외 발생")
+    void checkEmail_duplicate_exception() {
+        // given
+        String email = "123@123.com";
+        given(subscriptionRepository.existsByEmail(email))
+            .willReturn(true);
+
+        // when & then
+        SubscriptionException ex = assertThrows(SubscriptionException.class,
+            () -> subscriptionService.checkEmail(email));
+        assertThat(ex.getMessage()).contains("이미 구독중인 이메일입니다.");
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 구독 생성 시 예외 발생")
+    void createSubscription_userNotFound_exception() {
+        // given
+        given(quizCategoryRepository.findByCategoryTypeOrElseThrow("BACKEND"))
+            .willReturn(quizCategory);
+        given(userRepository.findBySerialId("user-serial-id"))
+            .willReturn(Optional.empty());
+
+        // when & then
+        UserException ex = assertThrows(UserException.class,
+            () -> subscriptionService.createSubscription(requestDto, authUser));
+        assertThat(ex.getMessage()).contains("해당 유저를 찾을 수 없습니다.");
+    }
 }


### PR DESCRIPTION

---

## 🔎 작업 내용

- 구독 생성할 때 이메일 검증에서 이메일 검증 후 통과하면 메일 보내는 순서로 변경
- 그에 따라서 AuthUser에 Email값을 사용하지 않도록 설정
- 구독생성 시 로그인을 하더라도 작성한 이메일로 구독이 되도록 

---

## 🛠️ 변경 사항

- AuthUser의 email 값으로 뭔갈 하는걸 전부 SerialId값으로 대처하도록 설정
- AccessToken에 email값 안들어가도록 설정

---

## 🧯 해결해야 할 문제

- 충분한 테스트는 안해봤는데 돌아가긴함.
---


### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 중복 여부를 사전에 검증하는 서비스가 추가되었습니다.

* **버그 수정**
  * 오타가 있던 예외 코드명이 `UNAUTHORIZE_ROLE`에서 `UNAUTHORIZED_ROLE`로 수정되었습니다.

* **리팩터**
  * 인증 관련 객체에서 이메일 필드가 제거되고, 사용자 식별이 이메일 대신 시리얼 ID로 변경되었습니다.
  * JWT 토큰 생성 시 이메일 정보가 더 이상 포함되지 않습니다.
  * 퀴즈 카테고리 관련 API에서 인증 사용자 파라미터가 제거되었습니다.

* **테스트**
  * 테스트 코드에서 이메일 대신 시리얼 ID 기반 사용자 조회로 변경되었습니다.
  * 예외 코드명 변경에 따른 테스트 코드가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->