### PR TITLE
Chore: 특정 퀴즈 선택률 계산 API 파라미터 수정 및 각 메서드명 변경 및 주석 추가

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -19,9 +19,9 @@ public class UserQuizAnswerController {
     private final UserQuizAnswerService userQuizAnswerService;
 
     // 정답 제출
-    @PostMapping("/{quizId}")
+    @PostMapping("/{quizSerialId}")
     public ApiResponse<Long> submitAnswer(
-        @PathVariable("quizId") String quizSerialId,
+        @PathVariable("quizSerialId") String quizSerialId,
         @RequestBody UserQuizAnswerRequestDto requestDto
     ) {
         Long userQuizAnswerId = userQuizAnswerService.submitAnswer(quizSerialId, requestDto);
@@ -37,9 +37,9 @@ public class UserQuizAnswerController {
     }
 
     // 특정 퀴즈의 선택률을 계산
-    @GetMapping("/{quizId}/select-rate")
+    @GetMapping("/{quizSerialId}/select-rate")
     public ApiResponse<SelectionRateResponseDto> calculateSelectionRateByOption(
-        @PathVariable("quizId") String quizSerialId) {
+        @PathVariable("quizSerialId") String quizSerialId) {
         return new ApiResponse<>(200, userQuizAnswerService.calculateSelectionRateByOption(quizSerialId));
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -18,27 +18,28 @@ public class UserQuizAnswerController {
 
     private final UserQuizAnswerService userQuizAnswerService;
 
-    //정답 제출
+    // 정답 제출
     @PostMapping("/{quizId}")
-    public ApiResponse<Long> answerSubmit(
-        @PathVariable("quizId") String quizId,
+    public ApiResponse<Long> submitAnswer(
+        @PathVariable("quizId") String quizSerialId,
         @RequestBody UserQuizAnswerRequestDto requestDto
     ) {
-        return new ApiResponse<>(200, userQuizAnswerService.answerSubmit(quizId, requestDto));
+        Long userQuizAnswerId = userQuizAnswerService.submitAnswer(quizSerialId, requestDto);
+        return new ApiResponse<>(200, userQuizAnswerId);
     }
 
-    //객관식 or 주관식 채점
+    // 객관식 or 주관식 채점
     @PostMapping("/simpleAnswer/{userQuizAnswerId}")
-    public ApiResponse<CheckSimpleAnswerResponseDto> checkSimpleAnswer(
+    public ApiResponse<CheckSimpleAnswerResponseDto> evaluateAnswer(
             @PathVariable("userQuizAnswerId") Long userQuizAnswerId
     ){
-        return new ApiResponse<>(200, userQuizAnswerService.checkSimpleAnswer(userQuizAnswerId));
+        return new ApiResponse<>(200, userQuizAnswerService.evaluateAnswer(userQuizAnswerId));
     }
 
+    // 특정 퀴즈의 선택률을 계산
     @GetMapping("/{quizId}/select-rate")
-    public ApiResponse<SelectionRateResponseDto> getSelectionRateByOption(
-        @PathVariable Long quizId) {
-        return new ApiResponse<>(200, userQuizAnswerService.getSelectionRateByOption(quizId));
+    public ApiResponse<SelectionRateResponseDto> calculateSelectionRateByOption(
+        @PathVariable("quizId") String quizSerialId) {
+        return new ApiResponse<>(200, userQuizAnswerService.calculateSelectionRateByOption(quizSerialId));
     }
-
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/service/UserQuizAnswerService.java
@@ -35,8 +35,19 @@ public class UserQuizAnswerService {
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
 
+    /**
+     * 사용자의 퀴즈 답변을 저장하는 메서드
+     * 중복 답변을 방지하고 사용자 정보와 함께 답변을 저장
+     * 
+     * @param quizSerialId 퀴즈 시리얼 ID (UUID)
+     * @param requestDto 사용자 답변 요청 DTO
+     * @return 저장된 사용자 퀴즈 답변의 ID
+     * @throws SubscriptionException 구독 정보를 찾을 수 없는 경우
+     * @throws QuizException 퀴즈를 찾을 수 없는 경우
+     * @throws UserQuizAnswerException 중복 답변인 경우
+     */
     @Transactional
-    public Long answerSubmit(String quizId, UserQuizAnswerRequestDto requestDto) {
+    public Long submitAnswer(String quizSerialId, UserQuizAnswerRequestDto requestDto) {
 
         // 구독 정보 조회
         Subscription subscription = subscriptionRepository.findBySerialId(
@@ -45,7 +56,7 @@ public class UserQuizAnswerService {
                 SubscriptionExceptionCode.NOT_FOUND_SUBSCRIPTION_ERROR));
 
         // 퀴즈 조회
-        Quiz quiz = quizRepository.findBySerialId(quizId)
+        Quiz quiz = quizRepository.findBySerialId(quizSerialId)
             .orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
 
         // 중복 답변 제출 막음
@@ -71,40 +82,24 @@ public class UserQuizAnswerService {
     }
 
     /**
-     * 객관식 or 주관식 채점
-     * @param userQuizAnswerId
-     * @return
+     * 사용자의 퀴즈 답변을 채점하고 결과를 반환하는 메서드
+     * 객관식과 주관식 문제를 모두 지원하며, 회원인 경우 점수를 업데이트
+     * 
+     * @param userQuizAnswerId 사용자 퀴즈 답변 ID
+     * @return 채점 결과를 포함한 응답 DTO
+     * @throws UserQuizAnswerException 답변을 찾을 수 없는 경우
      */
     @Transactional
-    public CheckSimpleAnswerResponseDto checkSimpleAnswer(Long userQuizAnswerId) {
+    public CheckSimpleAnswerResponseDto evaluateAnswer(Long userQuizAnswerId) {
         UserQuizAnswer userQuizAnswer = userQuizAnswerRepository.findWithQuizAndUserById(userQuizAnswerId).orElseThrow(
                 () -> new UserQuizAnswerException(UserQuizAnswerExceptionCode.NOT_FOUND_ANSWER)
         );
 
         Quiz quiz = userQuizAnswer.getQuiz();
 
-        boolean isCorrect;
-        if(quiz.getType().getScore() == 1){
-            isCorrect = userQuizAnswer.getUserAnswer().equals(quiz.getAnswer().substring(0, 1));
-        }else if(quiz.getType().getScore() == 3){
-            isCorrect = userQuizAnswer.getUserAnswer().trim().equals(quiz.getAnswer().trim());
-        }else{
-            throw new QuizException(QuizExceptionCode.NOT_FOUND_ERROR);
-        }
+        boolean isAnswerCorrect = getIsAnswerCorrect(quiz, userQuizAnswer);
 
-        User user = userQuizAnswer.getUser();
-        // 회원인 경우에만 점수 부여
-        if(user != null){
-            double score;
-            if(isCorrect){
-                score = user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp());
-            }else{
-                score = user.getScore() + 1;
-            }
-            user.updateScore(score);
-        }
-
-        userQuizAnswer.updateIsCorrect(isCorrect);
+        userQuizAnswer.updateIsCorrect(isAnswerCorrect);
 
         return new CheckSimpleAnswerResponseDto(
                 quiz.getQuestion(),
@@ -115,27 +110,75 @@ public class UserQuizAnswerService {
         );
     }
 
-    public SelectionRateResponseDto getSelectionRateByOption(Long quizId) {
-        List<UserAnswerDto> answers = userQuizAnswerRepository.findUserAnswerByQuizId(quizId);
+    /**
+     * 특정 퀴즈의 각 선택지별 선택률을 계산하는 메서드
+     * 모든 사용자의 답변을 집계하여 통계 정보를 반환
+     * 
+     * @param quizSerialId 퀴즈 시리얼 ID
+     * @return 선택지별 선택률과 총 응답 수를 포함한 응답 DTO
+     * @throws QuizException 퀴즈를 찾을 수 없는 경우
+     */
+    public SelectionRateResponseDto calculateSelectionRateByOption(String quizSerialId) {
+        Quiz quiz = quizRepository.findBySerialId(quizSerialId)
+            .orElseThrow(() -> new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
+        List<UserAnswerDto> answers = userQuizAnswerRepository.findUserAnswerByQuizId(quiz.getId());
 
         //보기별 선택 수 집계
-        Map<String, Long> counts = answers.stream()
+        Map<String, Long> selectionCounts = answers.stream()
             .map(UserAnswerDto::getUserAnswer)
             .filter(Objects::nonNull)
             .map(String::trim)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
         // 총 응답 수 계산
-        long total = counts.values().stream().mapToLong(Long::longValue).sum();
+        long totalResponses = selectionCounts.values().stream().mapToLong(Long::longValue).sum();
 
         // 선택률 계산
-        Map<String, Double> rates = counts.entrySet().stream()
+        Map<String, Double> selectionRates = selectionCounts.entrySet().stream()
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
-                e -> (double) e.getValue() / total
+                entry -> (double) entry.getValue() / totalResponses
             ));
 
-        return new SelectionRateResponseDto(rates, total);
+        return new SelectionRateResponseDto(selectionRates, totalResponses);
     }
 
+    /**
+     * 사용자의 답변이 정답인지 검수하고, 점수를 업데이트하는 메서드
+     * 퀴즈 타입에 따라 다른 채점 로직을 적용
+     * - 객관식 (score=1): 첫 글자만 비교
+     * - 주관식 (score=3): 전체 답변을 trim 비교
+     * 
+     * @param quiz 퀴즈 정보
+     * @param userQuizAnswer 사용자 답변 정보
+     * @return 답변 정답 여부
+     * @throws QuizException 지원하지 않는 퀴즈 타입인 경우
+     */
+    private boolean getIsAnswerCorrect(Quiz quiz, UserQuizAnswer userQuizAnswer) {
+        boolean answerCorrectness;
+        if(quiz.getType().getScore() == 1){
+            // 객관식: 첫 글자만 비교
+            answerCorrectness = userQuizAnswer.getUserAnswer().equals(quiz.getAnswer().substring(0, 1));
+        }else if(quiz.getType().getScore() == 3){
+            // 주관식: 전체 답변 비교 (공백 제거)
+            answerCorrectness = userQuizAnswer.getUserAnswer().trim().equals(quiz.getAnswer().trim());
+        }else{
+            throw new QuizException(QuizExceptionCode.NOT_FOUND_ERROR);
+        }
+
+        User user = userQuizAnswer.getUser();
+        // 회원인 경우에만 점수 부여
+        if(user != null){
+            double updatedScore;
+            if(answerCorrectness){
+                // 정답: 퀴즈 타입 점수 × 난이도 경험치
+                updatedScore = user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp());
+            }else{
+                // 오답: 기본 점수 1점
+                updatedScore = user.getScore() + 1;
+            }
+            user.updateScore(updatedScore);
+        }
+        return answerCorrectness;
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- `{quizId}/select-rate` 특정 퀴즈 선택률 계산 API 파라미터의 `quizId` 타입을 Long -> String으로 변경
   -  `UUID`이기 때문
-  `user-quiz-answer` Controller, Service 단에 메서드명을 가독성있게 수정하고, 주석을 추가하였습니다.

---


## 🧯 해결해야 할 문제

- 메서드명 변경 및 파라미터 타입 변경으로 테스트 코드 추가 예정

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 사용자 퀴즈 답변 관련 API의 메서드 및 파라미터 명칭이 보다 명확하게 변경되었습니다.
  * 일부 API의 경로 변수 타입이 일관성 있게 조정되었습니다.
  * 내부 로직이 개선되어 코드 가독성과 유지보수성이 향상되었습니다.

* **Style**
  * 주석 및 코드 포맷이 소폭 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->