### PR TITLE
Chore: 3차 배포 이후 프론트 연동 문제점 해결

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/JavaMailService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/JavaMailService.java
@@ -31,6 +31,7 @@ public class JavaMailService {
             context.setVariable("toEmail", subscription.getEmail());
             context.setVariable("question", quiz.getQuestion());
             context.setVariable("quizLink", MailLinkGenerator.generateQuizLink(subscription.getSerialId(), quiz.getSerialId()));
+            context.setVariable("subscriptionSettings", MailLinkGenerator.generateSubscriptionSettings(subscription.getSerialId()));
             String htmlContent = templateEngine.process("mail-template", context);
 
             MimeMessage message = mailSender.createMimeMessage();

--- a/cs25-batch/src/main/resources/templates/mail-template.html
+++ b/cs25-batch/src/main/resources/templates/mail-template.html
@@ -21,9 +21,9 @@
             <!-- Logo and Title in horizontal layout -->
             <table cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <td style="vertical-align: middle; padding-right: 12px;">
-                  <img src="cs25.png" alt="CS25" style="width: 28px; height: 28px;">
-                </td>
+<!--                <td style="vertical-align: middle; padding-right: 12px;">-->
+<!--                  <img src="cs25.png" alt="CS25" style="width: 28px; height: 28px;">-->
+<!--                </td>-->
                 <td style="vertical-align: middle;">
                   <h2 style="font-size: 20px; font-weight: 600; margin: 0; color: #1d4ed8;">오늘의 문제</h2>
                 </td>
@@ -39,7 +39,7 @@
             <!-- Question Box -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 40px 0;">
               <tr>
-                <td style="color: white; font-weight: 700; font-size: 28px; line-height: 1.6; margin: 0; text-align: center;">
+                <td style="color: white; font-weight: 700; font-size: 24px; line-height: 1.6; margin: 0; text-align: center;">
                   <span th:text="${question}">관계 대수에 대한 설명으로 틀린 것은?</span>
                 </td>
               </tr>

--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/service/ProfileService.java
@@ -118,6 +118,11 @@ public class ProfileService {
             () -> new UserException(UserExceptionCode.NOT_FOUND_USER)
         );
 
+        // 사용자에게 구독정보가 없으면 예외처리
+        if(user.getSubscription() == null) {
+            throw new UserException(UserExceptionCode.NOT_FOUND_SUBSCRIPTION);
+        }
+
         Long userId = user.getId();
 
         //유저 Id에 따른 구독 정보의 대분류 카테고리 조회

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
@@ -20,7 +20,7 @@ public class VerificationController {
     private final VerificationService verificationService;
     private final VerificationPreprocessingService preprocessingService;
 
-    @PostMapping()
+    @PostMapping
     public ApiResponse<String> issueVerificationCodeByEmail(
         @Valid @RequestBody VerificationIssueRequest request) {
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
@@ -21,13 +21,14 @@ public class VerificationPreprocessingService {
     public void isValidEmailCheck(
         @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email) {
 
+        /*
+         * 이미 구독정보에 등록된 이메일인지 확인하는 메서드
+         * 유저의 경우, 소셜이메일이 아닌 다른 이메일로 구독할 수 있기 때문에
+         * 따로 유저 이메일 중복 예외처리를 하지 않음
+         */
         if (subscriptionRepository.existsByEmail(email)) {
             throw new SubscriptionException(
                 SubscriptionExceptionCode.DUPLICATE_SUBSCRIPTION_EMAIL_ERROR);
-        }
-
-        if (userRepository.existsByEmail(email)) {
-            throw new UserException(UserExceptionCode.EMAIL_DUPLICATION);
         }
     }
 }


### PR DESCRIPTION

## 🔎 작업 내용

- 마이페이지(profile)에서 구독정보가 없으면 정답률 탭 예외처리 추가
- 구독신청할 때, 구독DB에서만 이메일 중복 검사하기
   - 소셜로그인 이메일과는 무관하게!
- 메일 템플릿 디자인 및 기능 개선

---

## 🧯 해결해야 할 문제

- 오늘의 문제 제대로 작동하는지 테스트 필요

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 구독 정보가 없는 사용자의 퀴즈 정답률 조회 시 명확한 오류 메시지가 제공됩니다.
  * 이메일 중복 확인 로직이 구독 이메일에만 적용되어, 사용자 이메일과 구독 이메일이 다를 수 있는 상황을 지원합니다.

* **스타일**
  * 이메일 템플릿에서 헤더의 로고가 숨겨지고, 본문 질문 텍스트의 글씨 크기가 줄어듭니다.

* **기타**
  * 이메일 템플릿에 구독 설정 링크가 추가되었습니다.
  * 일부 코드의 어노테이션 문법이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->