### PR TITLE
refactor: SSE 방식 sentence기반 리팩토링

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
@@ -23,23 +23,13 @@ public class AiController {
     private final FileLoaderService fileLoaderService;
     private final AiFeedbackQueueService aiFeedbackQueueService;
 
-    @GetMapping("/answers/{answerId}/feedback-word")
-    public SseEmitter streamWordFeedback(@PathVariable Long answerId) {
+    @GetMapping("/{answerId}/feedback")
+    public SseEmitter streamFeedback(@PathVariable Long answerId) {
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        aiFeedbackQueueService.enqueue(answerId, emitter, "word");
-        return emitter;
-    }
-
-    @GetMapping("/answers/{answerId}/feedback-sentence")
-    public SseEmitter streamSentenceFeedback(@PathVariable Long answerId) {
-        SseEmitter emitter = new SseEmitter(60_000L);
-        emitter.onTimeout(emitter::complete);
-        emitter.onError(emitter::completeWithError);
-
-        aiFeedbackQueueService.enqueue(answerId, emitter, "sentence");
+        aiFeedbackQueueService.enqueue(answerId, emitter);
         return emitter;
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
@@ -16,12 +16,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class AiFeedbackQueueService {
 
     public static final String DEDUPLICATION_SET_KEY = "ai-feedback-dedup-set";
+
     private final EmitterRegistry emitterRegistry;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public void enqueue(Long answerId, SseEmitter emitter, String mode) {
+    public void enqueue(Long answerId, SseEmitter emitter) {
         try {
-            // Redis Set을 통한 중복 체크
+            // Redis Set을 통한 중복 처리 방지
             Long added = redisTemplate.opsForSet()
                 .add(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
             if (added == null || added == 0) {
@@ -34,14 +35,16 @@ public class AiFeedbackQueueService {
 
             Map<String, Object> message = new HashMap<>();
             message.put("answerId", answerId);
-            message.put("mode", mode); // word/sentence 모드 구분 추가
 
             redisTemplate.opsForStream().add(RedisStreamConfig.STREAM_KEY, message);
 
         } catch (Exception e) {
+            log.error("Enqueue failed for answerId {}: {}", answerId, e.getMessage(), e);
+
+            // 롤백: emitterRegistry/Redis Set에서 제거
             emitterRegistry.remove(answerId);
-            redisTemplate.opsForSet()
-                .remove(DEDUPLICATION_SET_KEY, String.valueOf(answerId)); // 실패 시 롤백
+            redisTemplate.opsForSet().remove(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
+
             completeWithError(emitter, e);
         }
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -1,9 +1,7 @@
 package com.example.cs25service.domain.ai.service;
 
-import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.user.entity.User;
 import com.example.cs25entity.domain.user.repository.UserRepository;
-import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.ai.client.AiChatClient;
 import com.example.cs25service.domain.ai.exception.AiException;
@@ -11,10 +9,12 @@ import com.example.cs25service.domain.ai.exception.AiExceptionCode;
 import com.example.cs25service.domain.ai.prompt.AiPromptProvider;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AiFeedbackStreamProcessor {
@@ -26,44 +26,14 @@ public class AiFeedbackStreamProcessor {
     private final AiChatClient aiChatClient;
 
     @Transactional
-    public void streamWord(Long answerId, SseEmitter emitter) {
+    public void stream(Long answerId, SseEmitter emitter) {
         try {
-            var answer = prepare(answerId, emitter);
-            if (answer == null) {
-                return;
-            }
+            var answer = userQuizAnswerRepository.findById(answerId)
+                .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
 
-            var quiz = answer.getQuiz();
-            var docs = ragService.searchRelevant(quiz.getQuestion(), 3, 0.3);
-            String userPrompt = promptProvider.getFeedbackUser(quiz, answer, docs);
-            String systemPrompt = promptProvider.getFeedbackSystem();
-
-            send(emitter, "AI 응답 대기 중...");
-
-            StringBuilder wordBuffer = new StringBuilder();
-
-            aiChatClient.stream(systemPrompt, userPrompt)
-                .doOnNext(token -> {
-                    wordBuffer.append(token);
-                    if (token.equals(" ") || token.matches("[.,!?]")) {
-                        send(emitter, wordBuffer.toString());
-                        wordBuffer.setLength(0);
-                    }
-                })
-                .doOnComplete(() -> finalizeFeedback(answer, quiz, wordBuffer, emitter))
-                .doOnError(emitter::completeWithError)
-                .subscribe();
-
-        } catch (Exception e) {
-            emitter.completeWithError(e);
-        }
-    }
-
-    @Transactional
-    public void streamSentence(Long answerId, SseEmitter emitter) {
-        try {
-            var answer = prepare(answerId, emitter);
-            if (answer == null) {
+            if (answer.getAiFeedback() != null) {
+                emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
+                emitter.complete();
                 return;
             }
 
@@ -84,53 +54,36 @@ public class AiFeedbackStreamProcessor {
                         sentenceBuffer.setLength(0);
                     }
                 })
-                .doOnComplete(() -> finalizeFeedback(answer, quiz, sentenceBuffer, emitter))
+                .doOnComplete(() -> {
+                    try {
+                        if (sentenceBuffer.length() > 0) {
+                            send(emitter, sentenceBuffer.toString());
+                        }
+                        send(emitter, "[종료]");
+                        String feedback = sentenceBuffer.toString();
+                        boolean isCorrect = feedback.startsWith("정답");
+
+                        User user = answer.getUser();
+                        if (user != null) {
+                            double score = isCorrect
+                                ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel()
+                                .getExp())
+                                : user.getScore() + 1;
+                            user.updateScore(score);
+                        }
+
+                        answer.updateIsCorrect(isCorrect);
+                        answer.updateAiFeedback(feedback);
+                        userQuizAnswerRepository.save(answer);
+
+                        emitter.complete();
+                    } catch (Exception e) {
+                        emitter.completeWithError(e);
+                    }
+                })
                 .doOnError(emitter::completeWithError)
                 .subscribe();
 
-        } catch (Exception e) {
-            emitter.completeWithError(e);
-        }
-    }
-
-    private UserQuizAnswer prepare(Long answerId, SseEmitter emitter) throws IOException {
-        emitter.onTimeout(emitter::complete);
-        emitter.onError(emitter::completeWithError);
-
-        var answer = userQuizAnswerRepository.findById(answerId)
-            .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
-
-        if (answer.getAiFeedback() != null) {
-            emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
-            emitter.complete();
-            return null;
-        }
-        return answer;
-    }
-
-    private void finalizeFeedback(UserQuizAnswer answer, Quiz quiz, StringBuilder buffer,
-        SseEmitter emitter) {
-        try {
-            if (buffer.length() > 0) {
-                send(emitter, buffer.toString());
-            }
-
-            String feedback = buffer.toString();
-            boolean isCorrect = feedback.startsWith("정답");
-
-            User user = answer.getUser();
-            if (user != null) {
-                double score = isCorrect
-                    ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp())
-                    : user.getScore() + 1;
-                user.updateScore(score);
-            }
-
-            answer.updateIsCorrect(isCorrect);
-            answer.updateAiFeedback(feedback);
-            userQuizAnswerRepository.save(answer);
-
-            emitter.complete();
         } catch (Exception e) {
             emitter.completeWithError(e);
         }
@@ -140,7 +93,9 @@ public class AiFeedbackStreamProcessor {
         try {
             emitter.send(SseEmitter.event().data(data));
         } catch (IOException e) {
+            log.error("SSE send error: {}", e.getMessage(), e);
             emitter.completeWithError(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
@@ -72,7 +72,7 @@ public class AiService {
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        feedbackQueueService.enqueue(answerId, emitter, mode);
+        feedbackQueueService.enqueue(answerId, emitter);
         return emitter;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 컨트롤러 엔드포인트 다시 통합
- Redis Stream 메시지에서 mode 파라미터를 제거하고, 피드백 스트리밍 로직도 Word/Sentence 분기를 없애고 단일 흐름으로 정리
---

## 📌 참고 사항

 ```
eventSource.onmessage = (event) => {
  if (event.data === "[종료]") {
    console.log("SSE 스트림 정상 종료");
    eventSource.close();
    return;
  }
  console.log("받은 SSE 데이터:", event.data);
};
```
프론트에서 이렇게 사용하시면 오류로그 안나온다고 하는 것 같아요. 데이터 다 전송하면  complete쪽에 "[종료]"라고 넣어놨습니다.
