### PR TITLE
Refactor/221 : 짧은 대기 추가로 서버 안전하게 닫히는 시간확보

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/controller/AiController.java
@@ -23,23 +23,13 @@ public class AiController {
     private final FileLoaderService fileLoaderService;
     private final AiFeedbackQueueService aiFeedbackQueueService;
 
-    @GetMapping("/answers/{answerId}/feedback-word")
-    public SseEmitter streamWordFeedback(@PathVariable Long answerId) {
+    @GetMapping("/{answerId}/feedback")
+    public SseEmitter streamFeedback(@PathVariable Long answerId) {
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        aiFeedbackQueueService.enqueue(answerId, emitter, "word");
-        return emitter;
-    }
-
-    @GetMapping("/answers/{answerId}/feedback-sentence")
-    public SseEmitter streamSentenceFeedback(@PathVariable Long answerId) {
-        SseEmitter emitter = new SseEmitter(60_000L);
-        emitter.onTimeout(emitter::complete);
-        emitter.onError(emitter::completeWithError);
-
-        aiFeedbackQueueService.enqueue(answerId, emitter, "sentence");
+        aiFeedbackQueueService.enqueue(answerId, emitter);
         return emitter;
     }
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackQueueService.java
@@ -16,12 +16,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class AiFeedbackQueueService {
 
     public static final String DEDUPLICATION_SET_KEY = "ai-feedback-dedup-set";
+
     private final EmitterRegistry emitterRegistry;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public void enqueue(Long answerId, SseEmitter emitter, String mode) {
+    public void enqueue(Long answerId, SseEmitter emitter) {
         try {
-            // Redis Set을 통한 중복 체크
+            // Redis Set을 통한 중복 처리 방지
             Long added = redisTemplate.opsForSet()
                 .add(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
             if (added == null || added == 0) {
@@ -34,14 +35,16 @@ public class AiFeedbackQueueService {
 
             Map<String, Object> message = new HashMap<>();
             message.put("answerId", answerId);
-            message.put("mode", mode); // word/sentence 모드 구분 추가
 
             redisTemplate.opsForStream().add(RedisStreamConfig.STREAM_KEY, message);
 
         } catch (Exception e) {
+            log.error("Enqueue failed for answerId {}: {}", answerId, e.getMessage(), e);
+
+            // 롤백: emitterRegistry/Redis Set에서 제거
             emitterRegistry.remove(answerId);
-            redisTemplate.opsForSet()
-                .remove(DEDUPLICATION_SET_KEY, String.valueOf(answerId)); // 실패 시 롤백
+            redisTemplate.opsForSet().remove(DEDUPLICATION_SET_KEY, String.valueOf(answerId));
+
             completeWithError(emitter, e);
         }
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -1,9 +1,7 @@
 package com.example.cs25service.domain.ai.service;
 
-import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.user.entity.User;
 import com.example.cs25entity.domain.user.repository.UserRepository;
-import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
 import com.example.cs25service.domain.ai.client.AiChatClient;
 import com.example.cs25service.domain.ai.exception.AiException;
@@ -11,10 +9,12 @@ import com.example.cs25service.domain.ai.exception.AiExceptionCode;
 import com.example.cs25service.domain.ai.prompt.AiPromptProvider;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AiFeedbackStreamProcessor {
@@ -26,44 +26,14 @@ public class AiFeedbackStreamProcessor {
     private final AiChatClient aiChatClient;
 
     @Transactional
-    public void streamWord(Long answerId, SseEmitter emitter) {
+    public void stream(Long answerId, SseEmitter emitter) {
         try {
-            var answer = prepare(answerId, emitter);
-            if (answer == null) {
-                return;
-            }
+            var answer = userQuizAnswerRepository.findById(answerId)
+                .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
 
-            var quiz = answer.getQuiz();
-            var docs = ragService.searchRelevant(quiz.getQuestion(), 3, 0.3);
-            String userPrompt = promptProvider.getFeedbackUser(quiz, answer, docs);
-            String systemPrompt = promptProvider.getFeedbackSystem();
-
-            send(emitter, "AI 응답 대기 중...");
-
-            StringBuilder wordBuffer = new StringBuilder();
-
-            aiChatClient.stream(systemPrompt, userPrompt)
-                .doOnNext(token -> {
-                    wordBuffer.append(token);
-                    if (token.equals(" ") || token.matches("[.,!?]")) {
-                        send(emitter, wordBuffer.toString());
-                        wordBuffer.setLength(0);
-                    }
-                })
-                .doOnComplete(() -> finalizeFeedback(answer, quiz, wordBuffer, emitter))
-                .doOnError(emitter::completeWithError)
-                .subscribe();
-
-        } catch (Exception e) {
-            emitter.completeWithError(e);
-        }
-    }
-
-    @Transactional
-    public void streamSentence(Long answerId, SseEmitter emitter) {
-        try {
-            var answer = prepare(answerId, emitter);
-            if (answer == null) {
+            if (answer.getAiFeedback() != null) {
+                emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
+                emitter.complete();
                 return;
             }
 
@@ -84,53 +54,36 @@ public class AiFeedbackStreamProcessor {
                         sentenceBuffer.setLength(0);
                     }
                 })
-                .doOnComplete(() -> finalizeFeedback(answer, quiz, sentenceBuffer, emitter))
+                .doOnComplete(() -> {
+                    try {
+                        if (sentenceBuffer.length() > 0) {
+                            send(emitter, sentenceBuffer.toString());
+                        }
+                        send(emitter, "[종료]");
+                        String feedback = sentenceBuffer.toString();
+                        boolean isCorrect = feedback.startsWith("정답");
+
+                        User user = answer.getUser();
+                        if (user != null) {
+                            double score = isCorrect
+                                ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel()
+                                .getExp())
+                                : user.getScore() + 1;
+                            user.updateScore(score);
+                        }
+
+                        answer.updateIsCorrect(isCorrect);
+                        answer.updateAiFeedback(feedback);
+                        userQuizAnswerRepository.save(answer);
+
+                        emitter.complete();
+                    } catch (Exception e) {
+                        emitter.completeWithError(e);
+                    }
+                })
                 .doOnError(emitter::completeWithError)
                 .subscribe();
 
-        } catch (Exception e) {
-            emitter.completeWithError(e);
-        }
-    }
-
-    private UserQuizAnswer prepare(Long answerId, SseEmitter emitter) throws IOException {
-        emitter.onTimeout(emitter::complete);
-        emitter.onError(emitter::completeWithError);
-
-        var answer = userQuizAnswerRepository.findById(answerId)
-            .orElseThrow(() -> new AiException(AiExceptionCode.NOT_FOUND_ANSWER));
-
-        if (answer.getAiFeedback() != null) {
-            emitter.send(SseEmitter.event().data("이미 처리된 요청입니다."));
-            emitter.complete();
-            return null;
-        }
-        return answer;
-    }
-
-    private void finalizeFeedback(UserQuizAnswer answer, Quiz quiz, StringBuilder buffer,
-        SseEmitter emitter) {
-        try {
-            if (buffer.length() > 0) {
-                send(emitter, buffer.toString());
-            }
-
-            String feedback = buffer.toString();
-            boolean isCorrect = feedback.startsWith("정답");
-
-            User user = answer.getUser();
-            if (user != null) {
-                double score = isCorrect
-                    ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel().getExp())
-                    : user.getScore() + 1;
-                user.updateScore(score);
-            }
-
-            answer.updateIsCorrect(isCorrect);
-            answer.updateAiFeedback(feedback);
-            userQuizAnswerRepository.save(answer);
-
-            emitter.complete();
         } catch (Exception e) {
             emitter.completeWithError(e);
         }
@@ -140,7 +93,9 @@ public class AiFeedbackStreamProcessor {
         try {
             emitter.send(SseEmitter.event().data(data));
         } catch (IOException e) {
+            log.error("SSE send error: {}", e.getMessage(), e);
             emitter.completeWithError(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -60,6 +60,9 @@ public class AiFeedbackStreamProcessor {
                             send(emitter, sentenceBuffer.toString());
                         }
                         send(emitter, "[종료]");
+
+                        Thread.sleep(100);
+
                         String feedback = sentenceBuffer.toString();
                         boolean isCorrect = feedback.startsWith("정답");
 

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiService.java
@@ -72,7 +72,7 @@ public class AiService {
         emitter.onTimeout(emitter::complete);
         emitter.onError(emitter::completeWithError);
 
-        feedbackQueueService.enqueue(answerId, emitter, mode);
+        feedbackQueueService.enqueue(answerId, emitter);
         return emitter;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 짧은 대기 추가로 서버 안전하게 닫히는 시간확보

---

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
    - `UserService.createUser()` 메서드 추가
    - `@Email` 유효성 검증 적용

---

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
    - 문제: `@Transactional`이 적용되지 않음
    - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
    - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인
