### PR TITLE
fix: 구독있는 회원은 새로운 구독 못만들게 설정

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/user/exception/UserExceptionCode.java
@@ -15,6 +15,7 @@ public enum UserExceptionCode {
     TOKEN_NOT_MATCHED(false, HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰 값이 아닙니다."),
     NOT_FOUND_USER(false, HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_SUBSCRIPTION(false, HttpStatus.NOT_FOUND, "해당 유저에게 구독 정보가 없습니다."),
+    DUPLICATE_SUBSCRIPTION_ERROR(false, HttpStatus.CONFLICT, "이미 구독 정보가 있는 사용자입니다."),
     INACTIVE_USER(false, HttpStatus.BAD_REQUEST, "이미 삭제된 유저입니다.");
 
     private final boolean isSuccess;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/controller/VerificationController.java
@@ -1,12 +1,14 @@
 package com.example.cs25service.domain.verification.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.verification.dto.VerificationIssueRequest;
 import com.example.cs25service.domain.verification.dto.VerificationVerifyRequest;
 import com.example.cs25service.domain.verification.service.VerificationPreprocessingService;
 import com.example.cs25service.domain.verification.service.VerificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,9 +24,10 @@ public class VerificationController {
 
     @PostMapping
     public ApiResponse<String> issueVerificationCodeByEmail(
-        @Valid @RequestBody VerificationIssueRequest request) {
+        @Valid @RequestBody VerificationIssueRequest request,
+        @AuthenticationPrincipal AuthUser authUser) {
 
-        preprocessingService.isValidEmailCheck(request.getEmail());
+        preprocessingService.isValidEmailCheck(request.getEmail(), authUser);
         verificationService.issue(request.getEmail());
         return new ApiResponse<>(200, "인증코드가 발급되었습니다.");
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingService.java
@@ -3,6 +3,11 @@ package com.example.cs25service.domain.verification.service;
 import com.example.cs25entity.domain.subscription.exception.SubscriptionException;
 import com.example.cs25entity.domain.subscription.exception.SubscriptionExceptionCode;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25entity.domain.user.entity.User;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.exception.UserExceptionCode;
+import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +18,11 @@ import org.springframework.stereotype.Service;
 public class VerificationPreprocessingService {
 
     private final SubscriptionRepository subscriptionRepository;
+    private final UserRepository userRepository;
 
     public void isValidEmailCheck(
-        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email) {
+        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        AuthUser authUser) {
 
         /*
          * 이미 구독정보에 등록된 이메일인지 확인하는 메서드
@@ -26,5 +33,16 @@ public class VerificationPreprocessingService {
             throw new SubscriptionException(
                 SubscriptionExceptionCode.DUPLICATE_SUBSCRIPTION_EMAIL_ERROR);
         }
+
+        if (authUser != null) {
+            User user = userRepository.findBySerialId(authUser.getSerialId())
+                .orElseThrow(() -> new UserException(UserExceptionCode.NOT_FOUND_USER));
+
+            if (user.getSubscription() != null) {
+                throw new UserException(
+                    UserExceptionCode.DUPLICATE_SUBSCRIPTION_ERROR);
+            }
+        }
+
     }
 }

--- a/cs25-service/src/test/java/com/example/cs25service/domain/verification/controller/VerificationControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/verification/controller/VerificationControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25service.domain.security.dto.AuthUser;
 import com.example.cs25service.domain.verification.dto.VerificationIssueRequest;
 import com.example.cs25service.domain.verification.dto.VerificationVerifyRequest;
 import com.example.cs25service.domain.verification.service.VerificationPreprocessingService;
@@ -51,9 +53,10 @@ class VerificationControllerTest {
         void issueVerificationCode_success() throws Exception {
             // given
             VerificationIssueRequest request = new VerificationIssueRequest("test@example.com");
+            AuthUser authUser = new AuthUser("name", "serial-user-001", Role.USER);
 
             // when
-            doNothing().when(preprocessingService).isValidEmailCheck(anyString());
+            doNothing().when(preprocessingService).isValidEmailCheck(anyString(), authUser);
             doNothing().when(verificationService).issue(anyString());
 
             // then

--- a/cs25-service/src/test/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/verification/service/VerificationPreprocessingServiceTest.java
@@ -4,8 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.exception.SubscriptionException;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.entity.SocialType;
+import com.example.cs25entity.domain.user.entity.User;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.security.dto.AuthUser;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +32,9 @@ class VerificationPreprocessingServiceTest {
     @Mock
     private SubscriptionRepository subscriptionRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private VerificationPreprocessingService emailValidationService;
 
@@ -27,15 +42,18 @@ class VerificationPreprocessingServiceTest {
     @DisplayName("isValidEmailCheck 메서드는")
     class IsValidEmailCheck {
 
+        AuthUser authUser = null;
+
         @Test
         @DisplayName("중복이 없고 형식이 올바른 이메일일 때 예외를 던지지 않는다")
         void validEmail_noDuplication_success() {
             // given
             String email = "test@example.com";
+
             given(subscriptionRepository.existsByEmail(email)).willReturn(false);
 
             // when & then
-            assertDoesNotThrow(() -> emailValidationService.isValidEmailCheck(email));
+            assertDoesNotThrow(() -> emailValidationService.isValidEmailCheck(email, authUser));
         }
 
         @Test
@@ -47,7 +65,40 @@ class VerificationPreprocessingServiceTest {
 
             // when & then
             assertThrows(SubscriptionException.class,
-                () -> emailValidationService.isValidEmailCheck(email));
+                () -> emailValidationService.isValidEmailCheck(email, authUser));
+        }
+
+        @Test
+        @DisplayName("구독을 이미 하고 있는 사용자는 새로운 구독을 만들 수 없다.")
+        void duplicateSubscription_throwsUserException() {
+            // given
+            authUser = new AuthUser("name", "serial-user-001", Role.USER);
+            String email = "test@example.com";
+
+            Subscription subscription = Subscription.builder()
+                .email("test@example.com")
+                .category(QuizCategory.builder()
+                    .categoryType("BACKEND")
+                    .build())
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(1))
+                .subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+                .build();
+
+            User user = User.builder()
+                .name(authUser.getName())
+                .email(email)
+                .socialType(SocialType.KAKAO)
+                .subscription(subscription)
+                .build();
+
+            given(subscriptionRepository.existsByEmail(email)).willReturn(false);
+            given(userRepository.findBySerialId(authUser.getSerialId())).willReturn(
+                Optional.ofNullable(user));
+
+            // when & then
+            assertThrows(UserException.class,
+                () -> emailValidationService.isValidEmailCheck(email, authUser));
         }
     }
 }


### PR DESCRIPTION

## 🔎 작업 내용
- 구독있는 회원은 새로운 구독 못만들게 설정

---

## 🛠️ 변경 사항
- isValidEmailCheck 메서드에 분기점 추가
- 테스트코드 변경점 수렴

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인
