### PR TITLE
Chore: 채점 API 주소 변경

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/profile/controller/ProfileController.java
@@ -38,7 +38,7 @@ public class ProfileController {
     @GetMapping("/wrong-quiz")
     public ApiResponse<ProfileWrongQuizResponseDto> getWrongQuiz(
             @AuthenticationPrincipal AuthUser authUser,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ){
 
         return new ApiResponse<>(200, profileService.getWrongQuiz(authUser, pageable));

--- a/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/userQuizAnswer/controller/UserQuizAnswerController.java
@@ -29,7 +29,7 @@ public class UserQuizAnswerController {
     }
 
     // 객관식 or 주관식 채점
-    @PostMapping("/simpleAnswer/{userQuizAnswerId}")
+    @PostMapping("/evaluate/{userQuizAnswerId}")
     public ApiResponse<CheckSimpleAnswerResponseDto> evaluateAnswer(
             @PathVariable("userQuizAnswerId") Long userQuizAnswerId
     ){


### PR DESCRIPTION

## 🔎 작업 내용

- 틀린문제는 5개씩 가져오게 수정 (종현님이랑 겹침)
- 채점 API주소를 `evaluate/~`로 변경

---



---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * `/profile/wrong-quiz` 엔드포인트의 기본 페이지 크기가 20에서 5로 변경되었습니다.

* **리팩터**
  * 사용자 퀴즈 답안 평가 엔드포인트가 `/simpleAnswer/{userQuizAnswerId}`에서 `/evaluate/{userQuizAnswerId}`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->