### PR TITLE
Fix/240 : Ai 피드백 시 aifeedback,iscorrect 저장 되지 않는 버그 해결

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -67,8 +67,7 @@ public class AiFeedbackStreamProcessor {
                         if (sentenceBuffer.length() > 0) {
                             send(emitter, sentenceBuffer.toString());
                         }
-                        send(emitter, "[DONE]");
-                        Thread.sleep(100);
+                        send(emitter, "[종료]");
 
                         String feedback = fullFeedbackBuffer.toString();
                         boolean isCorrect = feedback.startsWith("정답");

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamProcessor.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
@@ -24,6 +25,7 @@ public class AiFeedbackStreamProcessor {
     private final RagService ragService;
     private final UserRepository userRepository;
     private final AiChatClient aiChatClient;
+    private final TransactionTemplate transactionTemplate;
 
     @Transactional
     public void stream(Long answerId, SseEmitter emitter) {
@@ -42,13 +44,19 @@ public class AiFeedbackStreamProcessor {
             String userPrompt = promptProvider.getFeedbackUser(quiz, answer, docs);
             String systemPrompt = promptProvider.getFeedbackSystem();
 
+            User user = answer.getUser();
+            Double userScore = user != null ? user.getScore() : null;
+
             send(emitter, "AI 응답 대기 중...");
 
             StringBuilder sentenceBuffer = new StringBuilder();
+            StringBuilder fullFeedbackBuffer = new StringBuilder();
 
             aiChatClient.stream(systemPrompt, userPrompt)
                 .doOnNext(token -> {
                     sentenceBuffer.append(token);
+                    fullFeedbackBuffer.append(token);
+
                     if (token.matches("[.!?]")) {
                         send(emitter, sentenceBuffer.toString());
                         sentenceBuffer.setLength(0);
@@ -59,22 +67,24 @@ public class AiFeedbackStreamProcessor {
                         if (sentenceBuffer.length() > 0) {
                             send(emitter, sentenceBuffer.toString());
                         }
-                        send(emitter, "[종료]");
-                        String feedback = sentenceBuffer.toString();
+                        send(emitter, "[DONE]");
+                        Thread.sleep(100);
+
+                        String feedback = fullFeedbackBuffer.toString();
                         boolean isCorrect = feedback.startsWith("정답");
 
-                        User user = answer.getUser();
-                        if (user != null) {
-                            double score = isCorrect
-                                ? user.getScore() + (quiz.getType().getScore() * quiz.getLevel()
-                                .getExp())
-                                : user.getScore() + 1;
-                            user.updateScore(score);
-                        }
-
-                        answer.updateIsCorrect(isCorrect);
-                        answer.updateAiFeedback(feedback);
-                        userQuizAnswerRepository.save(answer);
+                        transactionTemplate.executeWithoutResult(status -> {
+                            if (user != null && userScore != null) {
+                                double score = isCorrect
+                                    ? userScore + (quiz.getType().getScore() * quiz.getLevel().getExp())
+                                    : userScore + 1;
+                                user.updateScore(score);
+                                userRepository.save(user);
+                            }
+                            answer.updateIsCorrect(isCorrect);
+                            answer.updateAiFeedback(feedback);
+                            userQuizAnswerRepository.save(answer);
+                        });
 
                         emitter.complete();
                     } catch (Exception e) {

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -87,5 +87,5 @@ server.forward-headers-strategy=framework
 #Tomcat ??? ? ?? ??
 server.tomcat.max-threads=10
 server.tomcat.max-connections=10
-FRONT_END_URI=https://cs25.co.kr
+FRONT_END_URI=http://localhost:5173/
 


### PR DESCRIPTION
## 🔎 작업 내용

- SSE 스트리밍 완료 후 AI 피드백 저장과 사용자 점수 업데이트를 안전하게 처리하기 위해 트랜잭션 템플릿을 도입했습니다.
- 기존 `@Transactional` 내에서 `doOnComplete` 비동기 처리 중 DB 접근 시 예외가 발생하던 문제를 해결했습니다.

---

## 🛠️ 변경 사항

### AiFeedbackStreamProcessor

- `TransactionTemplate`을 주입받아 `stream()` 내 `doOnComplete()` 블록에서 DB 수정 작업을 `transactionTemplate.executeWithoutResult()`로 감쌌습니다.
    - 트랜잭션 범위를 명확히 분리해, 스트리밍 완료 후 별도 트랜잭션으로 안정적으로 데이터 수정
    - 기존 `@Transactional` 메서드 내부에서 리액티브 콜백으로 DB 접근 시 발생하던 LazyInitializationException, TransactionRequiredException 방지
- 응답 완료 후 사용자 점수 및 정답 여부 반영 시 안정성 확보

---

## 🧩 트러블 슈팅

- **문제**: 스트리밍 완료 이후 DB 업데이트 시 기존 트랜잭션 종료로 인해 예외 발생
    - 해결: `TransactionTemplate` 사용으로 트랜잭션을 명확히 분리하여 비동기 흐름과 DB 작업을 안전하게 결합

---

closed #240 

