### PR TITLE
Test/263 admin 도메인 테스트 코드

### DIFF
--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -25,29 +25,18 @@ public class QuizCustomRepositoryImpl implements QuizCustomRepository {
         QQuiz quiz = QQuiz.quiz;
         QQuizCategory category = QQuizCategory.quizCategory;
 
-        // 1. 소분류 ID들 가져오기
-        List<Long> subCategoryIds = queryFactory
-            .select(category.id)
-            .from(category)
-            .where(category.parent.id.eq(parentCategoryId))
-            .fetch();
-
-        if (subCategoryIds.isEmpty()) {
-            return List.of();
-        }
-
         // 2. 퀴즈 조회
         BooleanBuilder builder = new BooleanBuilder()
-            .and(quiz.category.id.in(subCategoryIds)) //내가 정한 카테고리에
+            .and(quiz.category.parent.id.eq(parentCategoryId)) //내가 정한 카테고리에
             .and(quiz.level.in(difficulties)) //정해진 난이도 그룹안에있으면서
             .and(quiz.type.in(targetTypes)); //퀴즈 타입은 이거야
 
         if (!solvedQuizIds.isEmpty()) {
             builder.and(quiz.id.notIn(solvedQuizIds)); //혹시라도 구독자가 문제를 푼 이력잉 ㅣㅆ으면 그것도 제외해야햄
         }
-
         return queryFactory
             .selectFrom(quiz)
+            .join(quiz.category, category)
             .where(builder)
             .limit(20)
             .fetch();

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepository.java
@@ -4,14 +4,16 @@ import com.example.cs25entity.domain.userQuizAnswer.dto.UserAnswerDto;
 import com.example.cs25entity.domain.userQuizAnswer.entity.UserQuizAnswer;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface UserQuizAnswerCustomRepository {
-    
+
     List<UserAnswerDto> findUserAnswerByQuizId(Long quizId);
 
     List<UserQuizAnswer> findByUserIdAndQuizCategoryId(Long userId, Long quizCategoryId);
+
+    List<UserQuizAnswer> findBySubscriptionIdAndQuizCategoryId(Long subscriptionId,
+        Long quizCategoryId);
 
     Set<Long> findRecentSolvedCategoryIds(Long userId, Long parentCategoryId, LocalDate afterDate);
 

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepositoryImpl.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/userQuizAnswer/repository/UserQuizAnswerCustomRepositoryImpl.java
@@ -13,7 +13,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +44,24 @@ public class UserQuizAnswerCustomRepositoryImpl implements UserQuizAnswerCustomR
             .join(quiz.category, category)
             .where(
                 answer.user.id.eq(userId),
+                category.id.eq(quizCategoryId)
+            )
+            .fetch();
+    }
+
+    @Override
+    public List<UserQuizAnswer> findBySubscriptionIdAndQuizCategoryId(Long subscriptionId,
+        Long quizCategoryId) {
+        QUserQuizAnswer answer = QUserQuizAnswer.userQuizAnswer;
+        QQuiz quiz = QQuiz.quiz;
+        QQuizCategory category = QQuizCategory.quizCategory;
+
+        return queryFactory
+            .selectFrom(answer)
+            .join(answer.quiz, quiz)
+            .join(quiz.category, category)
+            .where(
+                answer.subscription.id.eq(subscriptionId),
                 category.id.eq(quizCategoryId)
             )
             .fetch();
@@ -85,7 +102,7 @@ public class UserQuizAnswerCustomRepositoryImpl implements UserQuizAnswerCustomR
             )
             .fetchOne();
 
-        if(result == null) {
+        if (result == null) {
             throw new UserQuizAnswerException(UserQuizAnswerExceptionCode.DUPLICATED_ANSWER);
         }
         return result;

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizAdminController.java
@@ -6,12 +6,11 @@ import com.example.cs25service.domain.admin.dto.request.QuizCreateRequestDto;
 import com.example.cs25service.domain.admin.dto.request.QuizUpdateRequestDto;
 import com.example.cs25service.domain.admin.dto.response.QuizDetailDto;
 import com.example.cs25service.domain.admin.service.QuizAdminService;
-import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -32,9 +32,10 @@ public class QuizAdminController {
 
     /**
      * 문제 JSON 형식 업로드 컨트롤러
-     * @param file 파일 객체
+     *
+     * @param file         파일 객체
      * @param categoryType 카테고리 타입
-     * @param formatType 포맷 타입
+     * @param formatType   포맷 타입
      * @return 상태 텍스트를 반환
      */
     @PostMapping("/upload")
@@ -58,6 +59,7 @@ public class QuizAdminController {
 
     /**
      * 관리자 문제 목록 조회 컨트롤러 (기본값: 비추천/오름차순)
+     *
      * @param page 페이징 객체
      * @param size 몇개씩 불러올지
      * @return 문제 목록 DTO를 반환
@@ -72,6 +74,7 @@ public class QuizAdminController {
 
     /**
      * 관리자 문제 상세 조회 컨트롤러
+     *
      * @param quizId 문제 id
      * @return 문제 목록 DTO를 반환
      */
@@ -84,9 +87,11 @@ public class QuizAdminController {
 
     /**
      * 관리자 문제 등록 컨트롤러
+     *
      * @param requestDto 요청 DTO
      * @return 등록한 문제 id를 반환
      */
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public ApiResponse<Long> createQuiz(
         @RequestBody QuizCreateRequestDto requestDto
@@ -96,7 +101,8 @@ public class QuizAdminController {
 
     /**
      * 관리자 문제 수정 컨트롤러
-     * @param quizId 문제 id
+     *
+     * @param quizId     문제 id
      * @param requestDto 요청 DTO
      * @return 수정한 문제 DTO를 반환
      */
@@ -110,9 +116,11 @@ public class QuizAdminController {
 
     /**
      * 관리자 문제 삭제 컨트롤러
+     *
      * @param quizId 문제 id
      * @return 반환값 없음
      */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{quizId}")
     public ApiResponse<Void> deleteQuiz(
         @Positive @PathVariable(name = "quizId") Long quizId

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizCategoryAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/QuizCategoryAdminController.java
@@ -4,11 +4,9 @@ import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.admin.service.QuizCategoryAdminService;
 import com.example.cs25service.domain.quiz.dto.QuizCategoryRequestDto;
 import com.example.cs25service.domain.quiz.dto.QuizCategoryResponseDto;
-import com.example.cs25service.domain.security.dto.AuthUser;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,8 +24,7 @@ public class QuizCategoryAdminController {
 
     @PostMapping
     public ApiResponse<String> createQuizCategory(
-        @Valid @RequestBody QuizCategoryRequestDto request,
-        @AuthenticationPrincipal AuthUser authUser
+        @Valid @RequestBody QuizCategoryRequestDto request
     ) {
         quizCategoryService.createQuizCategory(request);
         return new ApiResponse<>(200, "카테고리 등록 성공");
@@ -36,17 +33,16 @@ public class QuizCategoryAdminController {
     @PutMapping("/{quizCategoryId}")
     public ApiResponse<QuizCategoryResponseDto> updateQuizCategory(
         @Valid @RequestBody QuizCategoryRequestDto request,
-        @NotNull @PathVariable Long quizCategoryId,
-        @AuthenticationPrincipal AuthUser authUser
-    ){
-        return new ApiResponse<>(200, quizCategoryService.updateQuizCategory(quizCategoryId, request));
+        @NotNull @PathVariable Long quizCategoryId
+    ) {
+        return new ApiResponse<>(200,
+            quizCategoryService.updateQuizCategory(quizCategoryId, request));
     }
 
     @DeleteMapping("/{quizCategoryId}")
     public ApiResponse<String> deleteQuizCategory(
-        @NotNull @PathVariable Long quizCategoryId,
-        @AuthenticationPrincipal AuthUser authUser
-    ){
+        @NotNull @PathVariable Long quizCategoryId
+    ) {
         quizCategoryService.deleteQuizCategory(quizCategoryId);
         return new ApiResponse<>(200, "카테고리가 삭제되었습니다.");
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/controller/UserAdminController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,6 +46,7 @@ public class UserAdminController {
     }
 
     //DELETE	관리자 사용자(회원) 탈퇴	/admin/users/{userId}
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{userId}")
     public ApiResponse<Void> disableUser(
         @Positive @PathVariable(name = "userId") Long userId
@@ -54,6 +57,7 @@ public class UserAdminController {
     }
 
     //PATCH	관리자 사용자(회원) 구독 상태 변경	/admin/users/{userId}/subscriptions
+
     @PatchMapping("/{userId}/subscriptions")
     public ApiResponse<String> updateAdminSubscription(
         @Positive @PathVariable(name = "userId") Long userId,
@@ -64,6 +68,7 @@ public class UserAdminController {
     }
 
     //DELETE	관리자 사용자(회원) 구독 취소 	/admin/users/{userId}/subscriptions
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{userId}/subscriptions")
     public ApiResponse<Void> cancelSubscription(
         @Positive @PathVariable(name = "userId") Long userId
@@ -74,6 +79,7 @@ public class UserAdminController {
     }
 
     //PATCH  관리자의 권한 수정 /admin/users/{userId}/role
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/{userId}/role")
     public ApiResponse<Void> patchUserRole(
         @Positive @PathVariable(name = "userId") Long userId,
@@ -82,6 +88,4 @@ public class UserAdminController {
         userAdminService.patchUserRole(userId, request);
         return new ApiResponse<>(204);
     }
-
-
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/QuizCreateRequestDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/QuizCreateRequestDto.java
@@ -25,4 +25,14 @@ public class QuizCreateRequestDto {
 
     @NotNull
     private QuizFormatType quizType;
+
+    public QuizCreateRequestDto(String question, String category, String choice, String answer,
+        String commentary, QuizFormatType quizType) {
+        this.question = question;
+        this.category = category;
+        this.choice = choice;
+        this.answer = answer;
+        this.commentary = commentary;
+        this.quizType = quizType;
+    }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/QuizUpdateRequestDto.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/admin/dto/request/QuizUpdateRequestDto.java
@@ -19,4 +19,14 @@ public class QuizUpdateRequestDto {
     private String commentary;
 
     private QuizFormatType quizType;
+
+    public QuizUpdateRequestDto(String question, String category, String choice, String answer,
+        String commentary, QuizFormatType quizType) {
+        this.question = question;
+        this.category = category;
+        this.choice = choice;
+        this.answer = answer;
+        this.commentary = commentary;
+        this.quizType = quizType;
+    }
 }

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/QuizAdminControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/QuizAdminControllerTest.java
@@ -1,0 +1,205 @@
+package com.example.cs25service.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.enums.QuizLevel;
+import com.example.cs25service.domain.admin.dto.request.QuizCreateRequestDto;
+import com.example.cs25service.domain.admin.dto.request.QuizUpdateRequestDto;
+import com.example.cs25service.domain.admin.dto.response.QuizDetailDto;
+import com.example.cs25service.domain.admin.service.QuizAdminService;
+import com.example.cs25service.domain.security.jwt.provider.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(QuizAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class QuizAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QuizAdminService quizAdminService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("POST /admin/quizzes/upload")
+    @WithMockUser(roles = "ADMIN")
+    class UploadQuizTest {
+
+        @Test
+        @DisplayName("JSON 파일 업로드 성공")
+        void uploadQuiz_success() throws Exception {
+            MockMultipartFile file = new MockMultipartFile(
+                "file", "quiz.json", MediaType.APPLICATION_JSON_VALUE,
+                "[{\"question\":\"test\"}]".getBytes()
+            );
+
+            mockMvc.perform(multipart("/admin/quizzes/upload")
+                    .file(file)
+                    .param("categoryType", "Backend")
+                    .param("formatType", "MULTIPLE_CHOICE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("문제 등록 성공"));
+
+            verify(quizAdminService).uploadQuizJson(any(), eq("Backend"),
+                eq(QuizFormatType.MULTIPLE_CHOICE));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/quizzes")
+    @WithMockUser(roles = "ADMIN")
+    class GetQuizDetailsTest {
+
+        @Test
+        @DisplayName("문제 목록 조회 성공")
+        void getQuizList_success() throws Exception {
+            Page<QuizDetailDto> quizPage = new PageImpl<>(List.of(
+                QuizDetailDto.builder().quizId(1L).question("Q1").build()
+            ));
+
+            given(quizAdminService.getAdminQuizDetails(1, 30)).willReturn(quizPage);
+
+            mockMvc.perform(get("/admin/quizzes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].quizId").value(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/quizzes/{quizId}")
+    @WithMockUser(roles = "ADMIN")
+    class GetQuizDetailTest {
+
+        @Test
+        @DisplayName("문제 상세 조회 성공")
+        void getQuizDetail_success() throws Exception {
+            QuizDetailDto dto = QuizDetailDto.builder()
+                .quizId(1L)
+                .question("Q1")
+                .build();
+
+            given(quizAdminService.getAdminQuizDetail(1L)).willReturn(dto);
+
+            mockMvc.perform(get("/admin/quizzes/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.quizId").value(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /admin/quizzes")
+    @WithMockUser(roles = "ADMIN")
+    class CreateQuizTest {
+
+        @Test
+        @DisplayName("문제 생성 성공")
+        void createQuiz_success() throws Exception {
+            QuizCreateRequestDto request = new QuizCreateRequestDto(
+                "질문1", "Database", null
+                , "답", "해설~~", QuizFormatType.SUBJECTIVE
+            );
+
+            given(quizAdminService.createQuiz(any())).willReturn(1L);
+
+            mockMvc.perform(post("/admin/quizzes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data").value(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /admin/quizzes/{quizId}")
+    @WithMockUser(roles = "ADMIN")
+    class UpdateQuizTest {
+
+        QuizCategory parentCategory = QuizCategory.builder()
+            .categoryType("BACKEND")
+            .build();
+
+        QuizCategory databaseCategory = QuizCategory.builder()
+            .categoryType("Database")
+            .parent(parentCategory)
+            .build();
+
+        Quiz quiz = Quiz.builder()
+            .answer("답1")
+            .category(databaseCategory)
+            .choice(null)
+            .commentary("해설123~~")
+            .level(QuizLevel.EASY)
+            .question("질문11")
+            .type(QuizFormatType.SUBJECTIVE)
+            .build();
+
+        @Test
+        @DisplayName("문제 수정 성공")
+        void updateQuiz_success() throws Exception {
+            QuizUpdateRequestDto request = new QuizUpdateRequestDto(
+                "질문11", "Database", null
+                , "답1", "해설123~~", QuizFormatType.SUBJECTIVE
+            );
+
+            QuizDetailDto updatedDto = new QuizDetailDto(quiz, 5L);
+
+            given(quizAdminService.updateQuiz(eq(1L), any())).willReturn(updatedDto);
+
+            mockMvc.perform(patch("/admin/quizzes/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.question").value("질문11"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /admin/quizzes/{quizId}")
+    @WithMockUser(roles = "ADMIN")
+    class DeleteQuizTest {
+
+        @Test
+        @DisplayName("문제 삭제 성공")
+        void deleteQuiz_success() throws Exception {
+            mockMvc.perform(delete("/admin/quizzes/1"))
+                .andExpect(status().isNoContent());
+
+            verify(quizAdminService).deleteQuiz(1L);
+        }
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/QuizCategoryAdminControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/QuizCategoryAdminControllerTest.java
@@ -1,0 +1,116 @@
+package com.example.cs25service.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.cs25service.domain.admin.service.QuizCategoryAdminService;
+import com.example.cs25service.domain.quiz.dto.QuizCategoryRequestDto;
+import com.example.cs25service.domain.quiz.dto.QuizCategoryResponseDto;
+import com.example.cs25service.domain.security.jwt.provider.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@ActiveProfiles("test")
+@WebMvcTest(QuizCategoryAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class QuizCategoryAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QuizCategoryAdminService quizCategoryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("POST /admin/quiz-categories")
+    @WithMockUser(roles = "ADMIN")
+    class CreateQuizCategoryTest {
+
+        @Test
+        @DisplayName("카테고리 생성 성공")
+        void createQuizCategory_success() throws Exception {
+            // given
+            QuizCategoryRequestDto request = QuizCategoryRequestDto.builder()
+                .category("Backend")
+                .parentId(null).build();
+
+            // when & then
+            mockMvc.perform(post("/admin/quiz-categories")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("카테고리 등록 성공"));
+
+            verify(quizCategoryService).createQuizCategory(any(QuizCategoryRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /admin/quiz-categories/{quizCategoryId}")
+    @WithMockUser(roles = "ADMIN")
+    class UpdateQuizCategoryTest {
+
+        @Test
+        @DisplayName("카테고리 수정 성공")
+        void updateQuizCategory_success() throws Exception {
+            // given
+            QuizCategoryRequestDto request = QuizCategoryRequestDto.builder()
+                .category("Backend")
+                .parentId(null)
+                .build();
+            QuizCategoryResponseDto response = QuizCategoryResponseDto.builder()
+                .main("cs")
+                .sub(null).build();
+
+            given(quizCategoryService.updateQuizCategory(eq(1L), any(QuizCategoryRequestDto.class)))
+                .willReturn(response);
+
+            // when & then
+            mockMvc.perform(put("/admin/quiz-categories/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.main").value("cs"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /admin/quiz-categories/{quizCategoryId}")
+    @WithMockUser(roles = "ADMIN")
+    class DeleteQuizCategoryTest {
+
+        @Test
+        @DisplayName("카테고리 삭제 성공")
+        void deleteQuizCategory_success() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/admin/quiz-categories/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("카테고리가 삭제되었습니다."));
+
+            verify(quizCategoryService).deleteQuizCategory(1L);
+        }
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/SubscriptionAdminControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/SubscriptionAdminControllerTest.java
@@ -1,0 +1,121 @@
+package com.example.cs25service.domain.admin.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.example.cs25service.domain.admin.dto.response.SubscriptionPageResponseDto;
+import com.example.cs25service.domain.admin.service.SubscriptionAdminService;
+import com.example.cs25service.domain.security.jwt.provider.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(SubscriptionAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SubscriptionAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SubscriptionAdminService subscriptionAdminService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("GET /admin/subscriptions")
+    @WithMockUser(roles = "ADMIN")
+    class GetSubscriptionLists {
+
+        @Test
+        @DisplayName("구독 목록 조회 성공")
+        void getSubscriptionList_success() throws Exception {
+            // given
+            Page<SubscriptionPageResponseDto> mockPage = new PageImpl<>(List.of(
+                SubscriptionPageResponseDto.builder()
+                    .id(1L)
+                    .email("test@email.com")
+                    .category("BACKEND")
+                    .serialId("subscription-SerialId-001")
+                    .isActive(true)
+                    .subscriptionType(
+                        Set.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY))
+                    .build()
+            ));
+
+            given(subscriptionAdminService.getAdminSubscriptions(1, 30)).willReturn(mockPage);
+
+            // when & then
+            mockMvc.perform(get("/admin/subscriptions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].email").value("test@email.com"))
+                .andExpect(jsonPath("$.data.content[0].active").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/subscriptions/{subscriptionId}")
+    @WithMockUser(roles = "ADMIN")
+    class GetSubscription {
+
+        @Test
+        @DisplayName("단일 구독 정보 조회 성공")
+        void getSubscription_success() throws Exception {
+            // given
+            SubscriptionPageResponseDto responseDto = SubscriptionPageResponseDto.builder()
+                .id(1L)
+                .email("test@email.com")
+                .category("BACKEND")
+                .serialId("subscription-SerialId-001")
+                .isActive(true)
+                .subscriptionType(
+                    Set.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY))
+                .build();
+
+            given(subscriptionAdminService.getSubscription(1L)).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(get("/admin/subscriptions/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("test@email.com"))
+                .andExpect(jsonPath("$.data.active").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /admin/subscriptions/{subscriptionId}")
+    @WithMockUser(roles = "ADMIN")
+    class DeleteSubscription {
+
+        @Test
+        @DisplayName("구독 삭제 성공")
+        void deleteSubscription_success() throws Exception {
+            // when & then
+            mockMvc.perform(patch("/admin/subscriptions/1"))
+                .andExpect(status().isOk());
+
+            verify(subscriptionAdminService).deleteSubscription(1L);
+        }
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/UserAdminControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/controller/UserAdminControllerTest.java
@@ -1,0 +1,179 @@
+package com.example.cs25service.domain.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.example.cs25entity.domain.subscription.entity.SubscriptionPeriod;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25service.domain.admin.dto.request.UserRoleUpdateRequestDto;
+import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
+import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
+import com.example.cs25service.domain.admin.service.UserAdminService;
+import com.example.cs25service.domain.security.jwt.provider.JwtTokenProvider;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ActiveProfiles("test")
+@WebMvcTest(UserAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserAdminService userAdminService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("GET /admin/users")
+    @WithMockUser(roles = "ADMIN")
+    class GetUserListsTest {
+
+        @Test
+        @DisplayName("회원 목록 조회 성공")
+        void getUserList_success() throws Exception {
+            Page<UserPageResponseDto> mockPage = new PageImpl<>(List.of(
+                UserPageResponseDto.builder().userId(1L).email("test@email.com").build()
+            ));
+
+            given(userAdminService.getAdminUsers(1, 30)).willReturn(mockPage);
+
+            mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].email").value("test@email.com"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /admin/users/{userId}")
+    @WithMockUser(roles = "ADMIN")
+    class GetUserDetailTest {
+
+        @Test
+        @DisplayName("회원 상세 조회 성공")
+        void getUserDetail_success() throws Exception {
+            UserDetailResponseDto dto = UserDetailResponseDto.builder()
+                .userInfo(UserPageResponseDto.builder()
+                    .userId(1L)
+                    .email("test@email.com")
+                    .build())
+                .build();
+
+            given(userAdminService.getAdminUserDetail(1L)).willReturn(dto);
+
+            mockMvc.perform(get("/admin/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userInfo.email").value("test@email.com"));
+        }
+    }
+
+    @Nested
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DisplayName("DELETE /admin/users/{userId}")
+    @WithMockUser(roles = "ADMIN")
+    class DisableUserTest {
+
+        @Test
+        @DisplayName("회원 탈퇴 성공")
+        void disableUser_success() throws Exception {
+            mockMvc.perform(delete("/admin/users/1"))
+                .andExpect(status().isNoContent());
+
+            verify(userAdminService).disableUser(1L);
+        }
+    }
+
+    @Nested
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DisplayName("PATCH /admin/users/{userId}/subscriptions")
+    @WithMockUser(roles = "ADMIN")
+    class UpdateSubscriptionTest {
+
+        @Test
+        @DisplayName("구독 수정 성공")
+        void updateSubscription_success() throws Exception {
+            SubscriptionRequestDto request = SubscriptionRequestDto.builder()
+                .active(true)
+                .category("Backend")
+                .email("test@example.com")
+                .period(SubscriptionPeriod.ONE_MONTH)
+                .days(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+                .build();
+
+            mockMvc.perform(patch("/admin/users/1/subscriptions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("구독 정보 수정 성공"));
+
+            verify(userAdminService).updateSubscription(eq(1L), any(SubscriptionRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /admin/users/{userId}/subscriptions")
+    @WithMockUser(roles = "ADMIN")
+    class CancelSubscriptionTest {
+
+        @Test
+        @DisplayName("구독 취소 성공")
+        void cancelSubscription_success() throws Exception {
+            mockMvc.perform(delete("/admin/users/1/subscriptions"))
+                .andExpect(status().isNoContent());
+
+            verify(userAdminService).cancelSubscription(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /admin/users/{userId}/role")
+    @WithMockUser(roles = "ADMIN")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    class PatchUserRoleTest {
+
+        @Test
+        @DisplayName("관리자 권한 수정 성공")
+        void patchUserRole_success() throws Exception {
+            UserRoleUpdateRequestDto request = new UserRoleUpdateRequestDto();
+            ReflectionTestUtils.setField(request, "role", Role.ADMIN);
+
+            mockMvc.perform(patch("/admin/users/1/role")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+
+            verify(userAdminService).patchUserRole(eq(1L), any(UserRoleUpdateRequestDto.class));
+        }
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/QuizAdminServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/QuizAdminServiceTest.java
@@ -1,0 +1,480 @@
+package com.example.cs25service.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.enums.QuizFormatType;
+import com.example.cs25entity.domain.quiz.exception.QuizException;
+import com.example.cs25entity.domain.quiz.exception.QuizExceptionCode;
+import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
+import com.example.cs25entity.domain.quiz.repository.QuizRepository;
+import com.example.cs25entity.domain.userQuizAnswer.repository.UserQuizAnswerRepository;
+import com.example.cs25service.domain.admin.dto.request.CreateQuizDto;
+import com.example.cs25service.domain.admin.dto.request.QuizCreateRequestDto;
+import com.example.cs25service.domain.admin.dto.request.QuizUpdateRequestDto;
+import com.example.cs25service.domain.admin.dto.response.QuizDetailDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class QuizAdminServiceTest {
+
+    @InjectMocks
+    private QuizAdminService quizAdminService;
+
+    @Mock
+    private QuizRepository quizRepository;
+
+    @Mock
+    private UserQuizAnswerRepository quizAnswerRepository;
+
+    @Mock
+    private QuizCategoryRepository quizCategoryRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Validator validator;
+
+    QuizCategory parentCategory;
+    QuizCategory subCategory1;
+
+    @BeforeEach
+    void setUp() {
+        // 상위 카테고리와 하위 카테고리 mock
+        parentCategory = QuizCategory.builder()
+            .categoryType("Backend")
+            .build();
+
+        subCategory1 = QuizCategory.builder()
+            .categoryType("InformationSystemManagement")
+            .parent(parentCategory)
+            .build();
+
+        ReflectionTestUtils.setField(parentCategory, "children", List.of(subCategory1));
+    }
+
+
+    @Nested
+    @DisplayName("uploadQuizJson 함수는")
+    class inUploadQuizJson {
+
+        @Test
+        @DisplayName("정상작동_시_퀴즈가저장된다")
+        void uploadQuizJson_success() throws Exception {
+            // given
+            String categoryType = "Backend";
+            QuizFormatType formatType = QuizFormatType.MULTIPLE_CHOICE;
+
+            // JSON을 담은 가짜 파일 생성
+            String json = """
+                [
+                  {
+                    "question": "HTTP는 상태를 유지한다.",
+                    "choice": "1.예/2.아니오",
+                    "answer": "2",
+                    "commentary": "HTTP는 무상태 프로토콜입니다.",
+                    "category": "InformationSystemManagement",
+                    "level": "EASY"
+                  }
+                ]
+                """;
+
+            MockMultipartFile file = new MockMultipartFile("file", "quiz.json", "application/json",
+                json.getBytes());
+
+            // CreateQuizDto mock
+            CreateQuizDto quizDto = CreateQuizDto.builder()
+                .question("HTTP는 상태를 유지한다.")
+                .choice("1.예/2.아니오")
+                .answer("2")
+                .commentary("HTTP는 무상태 프로토콜입니다.")
+                .category("InformationSystemManagement")
+                .level("EASY")
+                .build();
+
+            CreateQuizDto[] quizDtos = {quizDto};
+
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("Backend"))
+                .willReturn(parentCategory);
+
+            given(objectMapper.readValue(any(InputStream.class), eq(CreateQuizDto[].class)))
+                .willReturn(quizDtos);
+
+            given(validator.validate(any(CreateQuizDto.class)))
+                .willReturn(Collections.emptySet());
+
+            // when
+            quizAdminService.uploadQuizJson(file, categoryType, formatType);
+
+            // then
+            then(quizRepository).should(times(1)).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("정상작동_시_퀴즈가저장된다")
+        void uploadQuizJson_JSON_PARSING_FAILED_ERROR() throws Exception {
+            // given
+            MockMultipartFile file = new MockMultipartFile("file", "quiz.json", "application/json",
+                "invalid".getBytes());
+
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("Backend"))
+                .willReturn(parentCategory);
+
+            given(objectMapper.readValue(any(InputStream.class), eq(CreateQuizDto[].class)))
+                .willThrow(new IOException("파싱 오류"));
+
+            // when & then
+            assertThatThrownBy(() ->
+                quizAdminService.uploadQuizJson(file, "Backend", QuizFormatType.MULTIPLE_CHOICE)
+            ).isInstanceOf(QuizException.class)
+                .hasMessageContaining("JSON 파싱 실패");
+        }
+
+        @Test
+        @DisplayName("유효성 검증 실패 시 예외발생 한다")
+        void uploadQuizJson_QUIZ_VALIDATION_FAILED_ERROR() throws Exception {
+            // given
+            CreateQuizDto quizDto = CreateQuizDto.builder()
+                .question(null)  // 필수값 빠짐
+                .choice("1.예/2.아니오")
+                .answer("2")
+                .category("Infra")
+                .level("EASY")
+                .build();
+
+            CreateQuizDto[] quizDtos = {quizDto};
+
+            MockMultipartFile file = new MockMultipartFile("file", "quiz.json", "application/json",
+                "any".getBytes());
+
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("Backend"))
+                .willReturn(parentCategory);
+            given(objectMapper.readValue(any(InputStream.class), eq(CreateQuizDto[].class)))
+                .willReturn(quizDtos);
+
+            // 검증 실패 set
+            Set<ConstraintViolation<CreateQuizDto>> violations = Set.of(
+                mock(ConstraintViolation.class));
+            given(validator.validate(any(CreateQuizDto.class)))
+                .willReturn(violations);
+
+            // when & then
+            assertThatThrownBy(() ->
+                quizAdminService.uploadQuizJson(file, "Backend", QuizFormatType.MULTIPLE_CHOICE)
+            ).isInstanceOf(QuizException.class)
+                .hasMessageContaining("Quiz 유효성 검증 실패");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAdminQuizDetails 함수는")
+    class inGetAdminQuizDetails {
+
+        @Test
+        @DisplayName("정상 작동 시 퀴즈리스트를 반환한다")
+        void getAdminQuizDetails_success() {
+            // given
+            Quiz quiz = Quiz.builder()
+                .question("Spring이란?")
+                .answer("프레임워크")
+                .commentary("스프링은 프레임워크입니다.")
+                .choice(null)
+                .type(QuizFormatType.MULTIPLE_CHOICE)
+                .category(QuizCategory.builder().categoryType("SoftwareDevelopment")
+                    .parent(parentCategory).build())
+                .build();
+            ReflectionTestUtils.setField(quiz, "id", 1L);
+
+            Page<Quiz> quizPage = new PageImpl<>(List.of(quiz));
+
+            given(quizRepository.findAllOrderByCreatedAtDesc(any(Pageable.class)))
+                .willReturn(quizPage);
+            given(quizAnswerRepository.countByQuizId(1L))
+                .willReturn(3L);
+
+            // when
+            Page<QuizDetailDto> result = quizAdminService.getAdminQuizDetails(1, 10);
+
+            // then
+            assertThat(result).hasSize(1);
+            QuizDetailDto dto = result.getContent().get(0);
+            assertThat(dto.getQuestion()).isEqualTo("Spring이란?");
+            assertThat(dto.getAnswer()).isEqualTo("프레임워크");
+            assertThat(dto.getSolvedCnt()).isEqualTo(3L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAdminQuizDetail 함수는")
+    class inGetAdminQuizDetail {
+
+        @Test
+        @DisplayName("정상 작동 시 퀴즈리스트를 반환한다")
+        void getAdminQuizDetail_success() {
+            // given
+            Long quizId = 1L;
+
+            Quiz quiz = Quiz.builder()
+                .question("REST란?")
+                .answer("자원 기반 아키텍처")
+                .commentary("HTTP URI를 통해 자원을 명확히 구분합니다.")
+                .choice(null)
+                .type(QuizFormatType.MULTIPLE_CHOICE)
+                .category(QuizCategory.builder().categoryType("SoftwareDevelopment")
+                    .parent(parentCategory).build())
+                .build();
+            ReflectionTestUtils.setField(quiz, "id", 1L);
+
+            given(quizRepository.findByIdOrElseThrow(quizId)).willReturn(quiz);
+            given(quizAnswerRepository.countByQuizId(quizId)).willReturn(5L);
+
+            // when
+            QuizDetailDto result = quizAdminService.getAdminQuizDetail(quizId);
+
+            // then
+            assertThat(result.getQuizId()).isEqualTo(quizId);
+            assertThat(result.getQuestion()).isEqualTo("REST란?");
+            assertThat(result.getAnswer()).isEqualTo("자원 기반 아키텍처");
+            assertThat(result.getSolvedCnt()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("없는_id면_예외가 발생한다.")
+        void getAdminQuizDetail_NOT_FOUND_ERROR() {
+            // given
+            Long quizId = 999L;
+
+            given(quizRepository.findByIdOrElseThrow(quizId))
+                .willThrow(new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
+
+            // when & then
+            assertThatThrownBy(() -> quizAdminService.getAdminQuizDetail(quizId))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("해당 퀴즈를 찾을 수 없습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("createQuiz 함수는")
+    class inCreateQuiz {
+
+        QuizCreateRequestDto requestDto = new QuizCreateRequestDto();
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(requestDto, "question", "REST란?");
+            ReflectionTestUtils.setField(requestDto, "category", subCategory1.getCategoryType());
+            ReflectionTestUtils.setField(requestDto, "choice", null);
+            ReflectionTestUtils.setField(requestDto, "answer", "자원 기반 아키텍처");
+            ReflectionTestUtils.setField(requestDto, "commentary", "HTTP URI를 통해 자원을 명확히 구분합니다.");
+            ReflectionTestUtils.setField(requestDto, "quizType", QuizFormatType.SUBJECTIVE);
+        }
+
+        @Test
+        @DisplayName("정상 작동 시 퀴즈ID를 반환 한다")
+        void createQuiz_success() {
+            // given
+
+            Quiz savedQuiz = Quiz.builder()
+                .category(subCategory1)
+                .question(requestDto.getQuestion())
+                .answer(requestDto.getAnswer())
+                .choice(requestDto.getChoice())
+                .commentary(requestDto.getCommentary())
+                .build();
+            ReflectionTestUtils.setField(savedQuiz, "id", 1L);
+
+            given(
+                quizCategoryRepository.findByCategoryTypeOrElseThrow("InformationSystemManagement"))
+                .willReturn(subCategory1);
+
+            given(quizRepository.save(any(Quiz.class)))
+                .willReturn(savedQuiz);
+
+            // when
+            Long resultId = quizAdminService.createQuiz(requestDto);
+
+            // then
+            assertThat(resultId).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("카테고리가 없으면 예외가 발생한다")
+        void createQuiz_QUIZ_CATEGORY_NOT_FOUND_ERROR() {
+            // given
+            ReflectionTestUtils.setField(requestDto, "category", "NonExist");
+
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("NonExist"))
+                .willThrow(new QuizException(QuizExceptionCode.QUIZ_CATEGORY_NOT_FOUND_ERROR));
+
+            // when & then
+            assertThatThrownBy(() -> quizAdminService.createQuiz(requestDto))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("QuizCategory 를 찾을 수 없습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateQuiz 함수는")
+    class inUpdateQuiz {
+
+        QuizUpdateRequestDto requestDto = new QuizUpdateRequestDto();
+
+        @Test
+        @DisplayName("모든 필드를 정상적으로 업데이트하면 DTO를 반환한다")
+        void updateQuiz_success() {
+            // given
+            Long quizId = 1L;
+            Quiz quiz = createSampleQuiz();
+            ReflectionTestUtils.setField(quiz, "id", quizId);
+
+            ReflectionTestUtils.setField(requestDto, "question", "기존 문제");
+            ReflectionTestUtils.setField(requestDto, "category", subCategory1.getCategoryType());
+            ReflectionTestUtils.setField(requestDto, "choice", null);
+            ReflectionTestUtils.setField(requestDto, "answer", "1");
+            ReflectionTestUtils.setField(requestDto, "commentary", "기존 해설");
+            ReflectionTestUtils.setField(requestDto, "quizType", QuizFormatType.SUBJECTIVE);
+
+            given(quizRepository.findByIdOrElseThrow(quizId)).willReturn(quiz);
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow(
+                "InformationSystemManagement")).willReturn(subCategory1);
+            given(quizAnswerRepository.countByQuizId(quizId)).willReturn(5L);
+
+            // when
+            QuizDetailDto result = quizAdminService.updateQuiz(quizId, requestDto);
+
+            // then
+            assertThat(result.getQuestion()).isEqualTo("기존 문제");
+            assertThat(result.getCommentary()).isEqualTo("기존 해설");
+            assertThat(result.getCategory()).isEqualTo("InformationSystemManagement");
+            assertThat(result.getChoice()).isEqualTo(null);
+            assertThat(result.getType()).isEqualTo("SUBJECTIVE");
+            assertThat(result.getSolvedCnt()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("카테고리만 변경되면 category 만 업데이트된다")
+        void updateQuiz_category_success() {
+            // given
+            Long quizId = 1L;
+            Quiz quiz = createSampleQuiz();
+            ReflectionTestUtils.setField(quiz, "id", quizId);
+            ReflectionTestUtils.setField(requestDto, "category", "Programming");
+
+            QuizCategory newCategory = QuizCategory.builder()
+                .categoryType("Programming")
+                .parent(parentCategory)
+                .build();
+
+            ReflectionTestUtils.setField(parentCategory, "children",
+                List.of(subCategory1, newCategory));
+
+            given(quizRepository.findByIdOrElseThrow(quizId)).willReturn(quiz);
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("Programming")).willReturn(
+                newCategory);
+            given(quizAnswerRepository.countByQuizId(quizId)).willReturn(0L);
+
+            // when
+            QuizDetailDto result = quizAdminService.updateQuiz(quizId, requestDto);
+
+            // then
+            assertThat(result.getCategory()).isEqualTo("Programming");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 퀴즈 ID면 예외가 발생한다")
+        void updateQuiz_NOT_FOUND_ERROR() {
+            // given
+            Long quizId = 999L;
+
+            ReflectionTestUtils.setField(requestDto, "question", "변경된 질문121");
+
+            given(quizRepository.findByIdOrElseThrow(quizId))
+                .willThrow(new QuizException(QuizExceptionCode.NOT_FOUND_ERROR));
+
+            // when & then
+            assertThatThrownBy(() -> quizAdminService.updateQuiz(quizId, requestDto))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("해당 퀴즈를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리면 예외가 발생한다")
+        void updateQuiz_QUIZ_CATEGORY_NOT_FOUND_ERROR() {
+            // given
+            Long quizId = 1L;
+            Quiz quiz = createSampleQuiz();
+            ReflectionTestUtils.setField(quiz, "id", quizId);
+            ReflectionTestUtils.setField(requestDto, "category", "NonExist");
+
+            given(quizRepository.findByIdOrElseThrow(quizId)).willReturn(quiz);
+            given(quizCategoryRepository.findByCategoryTypeOrElseThrow("NonExist"))
+                .willThrow(new QuizException(QuizExceptionCode.QUIZ_CATEGORY_NOT_FOUND_ERROR));
+
+            // when & then
+            assertThatThrownBy(() -> quizAdminService.updateQuiz(quizId, requestDto))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("QuizCategory 를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("퀴즈 타입을 MULTIPLE_CHOICE로 변경하려는데 choice가 없으면 예외 발생")
+        void updateQuiz_MULTIPLE_CHOICE_REQUIRE_ERROR() {
+            // given
+            Long quizId = 1L;
+            Quiz quiz = createSampleQuiz();
+            ReflectionTestUtils.setField(quiz, "id", quizId);
+            ReflectionTestUtils.setField(requestDto, "quizType", QuizFormatType.MULTIPLE_CHOICE);
+
+            given(quizRepository.findByIdOrElseThrow(quizId)).willReturn(quiz);
+
+            // when & then
+            assertThatThrownBy(() -> quizAdminService.updateQuiz(quizId, requestDto))
+                .isInstanceOf(QuizException.class)
+                .hasMessageContaining("객관식 문제에는 선택지가 필요합니다.");
+        }
+
+        // 헬퍼 메서드
+        private Quiz createSampleQuiz() {
+            return Quiz.builder()
+                .question("기존 문제")
+                .answer("1")
+                .commentary("기존 해설")
+                .choice(null)
+                .type(QuizFormatType.SUBJECTIVE)
+                .category(subCategory1)
+                .build();
+        }
+    }
+
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/QuizAdminServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/QuizAdminServiceTest.java
@@ -141,7 +141,7 @@ class QuizAdminServiceTest {
         }
 
         @Test
-        @DisplayName("정상작동_시_퀴즈가저장된다")
+        @DisplayName("JSON_파싱_실패_시_예외발생")
         void uploadQuizJson_JSON_PARSING_FAILED_ERROR() throws Exception {
             // given
             MockMultipartFile file = new MockMultipartFile("file", "quiz.json", "application/json",

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/SubscriptionAdminServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/SubscriptionAdminServiceTest.java
@@ -1,0 +1,148 @@
+package com.example.cs25service.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.quiz.repository.QuizCategoryRepository;
+import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.example.cs25entity.domain.subscription.entity.Subscription;
+import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import com.example.cs25service.domain.admin.dto.response.SubscriptionPageResponseDto;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionAdminServiceTest {
+
+    @InjectMocks
+    private SubscriptionAdminService subscriptionAdminService;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private QuizCategoryRepository categoryRepository; // assuming a Category repository is used
+
+    QuizCategory parentCategory;
+    QuizCategory subCategory1;
+    Subscription subscription;
+
+    @BeforeEach
+    void setUp() {
+        // 상위 카테고리와 하위 카테고리 mock
+        parentCategory = QuizCategory.builder()
+            .categoryType("Backend")
+            .build();
+
+        subCategory1 = QuizCategory.builder()
+            .categoryType("InformationSystemManagement")
+            .parent(parentCategory)
+            .build();
+
+        subscription = Subscription.builder()
+            .email("test@example.com")
+            .category(parentCategory)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusMonths(1))
+            .subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+            .build();
+
+        ReflectionTestUtils.setField(parentCategory, "children", List.of(subCategory1));
+        ReflectionTestUtils.setField(subscription, "id", 1L);
+        ReflectionTestUtils.setField(subscription, "serialId", "serial-subscription-001");
+    }
+
+    @Nested
+    @DisplayName("getAdminSubscriptions 함수는")
+    class inGetAdminSubscriptions {
+        
+        @Test
+        @DisplayName("정상작동_시_구독리스트가_반환된다")
+        void getAdminSubscriptions_success() {
+            // given
+            int page = 1;
+            int size = 10;
+
+            // Page<Subscription> 객체 생성
+            Page<Subscription> subscriptionPage = new PageImpl<>(List.of(subscription));
+
+            given(subscriptionRepository.findAllByOrderByIdAsc(any(Pageable.class)))
+                .willReturn(subscriptionPage);
+
+            // when
+            Page<SubscriptionPageResponseDto> result = subscriptionAdminService.getAdminSubscriptions(
+                page, size);
+
+            // then
+            assertThat(result.getContent()).isNotNull();  // null 검사
+            assertThat(result.getContent()).hasSize(1);   // 크기 확인
+            SubscriptionPageResponseDto dto = result.getContent().get(0);
+            assertThat(dto.getId()).isEqualTo(1L);
+            assertThat(dto.getCategory()).isEqualTo("Backend");
+            assertThat(dto.getEmail()).isEqualTo("test@example.com");
+            assertThat(dto.isActive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubscription 함수는")
+    class inGetSubscription {
+
+        @Test
+        @DisplayName("정상작동_시_구독자가_반환된다")
+        void getSubscription_success() {
+            // given
+            Long subscriptionId = 1L;
+
+            given(subscriptionRepository.findByIdOrElseThrow(subscriptionId))
+                .willReturn(subscription);
+
+            // when
+            SubscriptionPageResponseDto result = subscriptionAdminService.getSubscription(
+                subscriptionId);
+
+            // then
+            assertThat(result.getId()).isEqualTo(subscriptionId);
+            assertThat(result.getCategory()).isEqualTo("Backend");
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+            assertThat(result.isActive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteSubscription 함수는")
+    class inDeleteSubscription {
+
+        @Test
+        @DisplayName("정상작동_시_구독자가_비활성화된다")
+        void deleteSubscription_success() {
+            // given
+            Long subscriptionId = 1L;
+
+            given(subscriptionRepository.findByIdOrElseThrow(subscriptionId))
+                .willReturn(subscription);
+
+            // when
+            subscriptionAdminService.deleteSubscription(subscriptionId);
+
+            // then
+            assertThat(
+                subscription.isActive()).isFalse();
+        }
+    }
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/UserAdminServiceTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/admin/service/UserAdminServiceTest.java
@@ -1,0 +1,286 @@
+package com.example.cs25service.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.example.cs25entity.domain.quiz.entity.QuizCategory;
+import com.example.cs25entity.domain.subscription.entity.DayOfWeek;
+import com.example.cs25entity.domain.subscription.entity.Subscription;
+import com.example.cs25entity.domain.subscription.entity.SubscriptionHistory;
+import com.example.cs25entity.domain.subscription.repository.SubscriptionHistoryRepository;
+import com.example.cs25entity.domain.user.entity.Role;
+import com.example.cs25entity.domain.user.entity.SocialType;
+import com.example.cs25entity.domain.user.entity.User;
+import com.example.cs25entity.domain.user.exception.UserException;
+import com.example.cs25entity.domain.user.repository.UserRepository;
+import com.example.cs25service.domain.admin.dto.request.UserRoleUpdateRequestDto;
+import com.example.cs25service.domain.admin.dto.response.UserDetailResponseDto;
+import com.example.cs25service.domain.admin.dto.response.UserPageResponseDto;
+import com.example.cs25service.domain.subscription.dto.SubscriptionRequestDto;
+import com.example.cs25service.domain.subscription.service.SubscriptionService;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserAdminServiceTest {
+
+    @InjectMocks
+    private UserAdminService userAdminService;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubscriptionHistoryRepository subscriptionHistoryRepository;
+
+    QuizCategory parentCategory;
+    User user;
+    Subscription subscription;
+
+    @BeforeEach
+    void setUp() {
+        // 상위 카테고리와 하위 카테고리 mock
+        parentCategory = QuizCategory.builder()
+            .categoryType("Backend")
+            .build();
+
+        subscription = Subscription.builder()
+            .startDate(LocalDate.now().minusDays(10))
+            .endDate(LocalDate.now())
+            .subscriptionType(EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+            .email("sub@email.com")
+            .category(parentCategory)
+            .build();
+
+        user = User.builder()
+            .email("test@email.com")
+            .name("테스트")
+            .role(Role.USER)
+            .socialType(SocialType.KAKAO)
+            .score(0)
+            .build();
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("getAdminUsers() 는 ")
+    class GetAdminUsersTest {
+
+        @Test
+        @DisplayName("페이지네이션된 유저 리스트 반환")
+        void getAdminUsers_success() {
+            // given
+            user.updateSubscription(subscription);
+
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(userRepository.findAllByOrderByIdAsc(pageable)).willReturn(userPage);
+
+            // when
+            Page<UserPageResponseDto> result = userAdminService.getAdminUsers(1, 10);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).getEmail()).isEqualTo("test@email.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAdminUserDetail()")
+    class GetAdminUserDetailTest {
+
+        @Test
+        @DisplayName("구독이 없는 유저 상세 정보 반환")
+        void getUserDetail_noSubscription() {
+            // given
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            // when
+            UserDetailResponseDto result = userAdminService.getAdminUserDetail(1L);
+
+            // then
+            assertThat(result.getUserInfo().getEmail()).isEqualTo("test@email.com");
+            assertThat(result.getSubscriptionInfo()).isNull();
+            assertThat(result.getSubscriptionLog()).isNull();
+        }
+
+        @Test
+        @DisplayName("구독이 있는 유저 상세 정보 반환")
+        void getUserDetail_withSubscription() {
+            // given
+            ReflectionTestUtils.setField(subscription, "id", 1L);
+            user.updateSubscription(subscription);
+
+            SubscriptionHistory history = SubscriptionHistory.builder()
+                .subscription(subscription)
+                .category(parentCategory)
+                .build();
+
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+            given(subscriptionHistoryRepository.findAllBySubscriptionId(1L)).willReturn(
+                List.of(history));
+
+            // when
+            UserDetailResponseDto result = userAdminService.getAdminUserDetail(1L);
+
+            // then
+            assertThat(result.getUserInfo().getEmail()).isEqualTo("test@email.com");
+            assertThat(result.getSubscriptionInfo()).isNotNull();
+            assertThat(result.getSubscriptionLog()).hasSize(1);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("disableUser()")
+    class DisableUserTest {
+
+        @Test
+        @DisplayName("활성 유저를 비활성화 처리")
+        void disable_active_user() {
+            User user = mock(User.class);
+            given(user.isActive()).willReturn(true);
+            given(user.getSubscription()).willReturn(null);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            userAdminService.disableUser(1L);
+
+            verify(user).updateDisableUser();
+        }
+
+        @Test
+        @DisplayName("이미 비활성화된 유저 예외 발생")
+        void disable_inactive_user_throws() {
+            User user = mock(User.class);
+            given(user.isActive()).willReturn(false);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            assertThatThrownBy(() -> userAdminService.disableUser(1L))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining("이미 삭제된 유저입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateSubscription()")
+    class UpdateSubscriptionTest {
+
+        @Test
+        @DisplayName("구독 정보 수정 성공")
+        void update_subscription_success() {
+            Subscription subscription = mock(Subscription.class);
+            User user = mock(User.class);
+            given(user.getSubscription()).willReturn(subscription);
+            given(subscription.getSerialId()).willReturn("sub-123");
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            SubscriptionRequestDto request = mock(SubscriptionRequestDto.class);
+
+            userAdminService.updateSubscription(1L, request);
+
+            verify(subscriptionService).updateSubscription("sub-123", request);
+        }
+
+        @Test
+        @DisplayName("구독 정보 없음 예외 발생")
+        void update_subscription_not_found() {
+            User user = mock(User.class);
+            given(user.getSubscription()).willReturn(null);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            assertThatThrownBy(
+                () -> userAdminService.updateSubscription(1L, mock(SubscriptionRequestDto.class)))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining("해당 유저에게 구독 정보가 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelSubscription()")
+    class CancelSubscriptionTest {
+
+        @Test
+        @DisplayName("구독 취소 성공")
+        void cancel_subscription_success() {
+
+            Subscription subscription = mock(Subscription.class);
+            User user = mock(User.class);
+            given(user.getSubscription()).willReturn(subscription);
+            given(subscription.getSerialId()).willReturn("sub-456");
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            userAdminService.cancelSubscription(1L);
+
+            verify(subscriptionService).cancelSubscription("sub-456");
+        }
+
+        @Test
+        @DisplayName("구독 없음 예외 발생")
+        void cancel_subscription_not_found() {
+            User user = mock(User.class);
+            given(user.getSubscription()).willReturn(null);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            assertThatThrownBy(() -> userAdminService.cancelSubscription(1L))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining("해당 유저에게 구독 정보가 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("patchUserRole()")
+    class PatchUserRoleTest {
+
+        @Test
+        @DisplayName("역할이 다르면 업데이트 수행")
+        void patch_user_role_success() {
+            User user = mock(User.class);
+            given(user.getRole()).willReturn(Role.USER);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            UserRoleUpdateRequestDto request = mock(UserRoleUpdateRequestDto.class);
+            given(request.getRole()).willReturn(Role.ADMIN);
+
+            userAdminService.patchUserRole(1L, request);
+
+            verify(user).updateRole(Role.ADMIN);
+        }
+
+        @Test
+        @DisplayName("요청 역할이 null이면 예외")
+        void patch_user_role_null() {
+            User user = mock(User.class);
+            given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
+
+            UserRoleUpdateRequestDto request = mock(UserRoleUpdateRequestDto.class);
+            given(request.getRole()).willReturn(null);
+
+            assertThatThrownBy(() -> userAdminService.patchUserRole(1L, request))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining("역할 값이 잘못되었습니다.");
+        }
+    }
+
+}

--- a/cs25-service/src/test/java/com/example/cs25service/domain/users/controller/UserControllerTest.java
+++ b/cs25-service/src/test/java/com/example/cs25service/domain/users/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,6 +28,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ActiveProfiles("test")
 @WebMvcTest(UserController.class)
@@ -46,6 +48,7 @@ class UserControllerTest {
     @Test
     @DisplayName("유저 탈퇴 요청 성공 시 204 반환")
     @WithMockUser(username = "tofha")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     void deleteUser_success() throws Exception {
         // given
         AuthUser mockUser = mock(AuthUser.class);


### PR DESCRIPTION
## 🔎 작업 내용

- admin service, controller 테스트 코드 추가
- 퀴즈뽑기 함수 QueryDSL 오류 수정, 성능개선

---

## 🛠️ 변경 사항

- adminController 내부에 사용하지 않는 AuthUser 삭제
- 퀴즈뽑기 함수에서 사용하는 QueryDSL 함수 추가,  for문 사용 줄이기, 쿼리 한번줄였음
- 테스트 코드 추가



## 📌 참고 사항

- 테스트 커버리지 54프로 달성
![image](https://github.com/user-attachments/assets/74d6c326-d747-49c5-a59b-af27fa078fe0)


closed #263 


---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 퀴즈 생성 및 수정 요청 DTO에 모든 필드를 초기화하는 생성자가 추가되었습니다.
  * 사용자 퀴즈 답변 조회 시 구독 ID와 카테고리 ID로 필터링하는 새로운 메서드가 추가되었습니다.

* **버그 수정**
  * 오늘의 퀴즈 정확도 및 풀이 퀴즈 ID 계산 방식이 간소화되어 정확도가 향상되었습니다.

* **리팩터링**
  * 퀴즈 조회 쿼리가 간소화되어 성능과 가독성이 개선되었습니다.
  * 에세이/비에세이 퀴즈 유형 결정 로직이 단순화되었습니다.

* **문서화**
  * 관리자 퀴즈 컨트롤러의 Javadoc이 개선되었습니다.

* **스타일**
  * 불필요한 import와 코드 포맷이 정리되었습니다.

* **테스트**
  * 관리자 및 사용자 관련 컨트롤러, 서비스의 단위/통합 테스트가 대폭 추가되어 안정성이 강화되었습니다.

* **기타**
  * 일부 관리자 컨트롤러의 인증 파라미터가 제거되어 API 사용이 간편해졌습니다.
  * 관리자 API의 HTTP 상태 코드 명시가 추가되어 응답 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->