### PR TITLE
fix: 쿠키값 필요없어서 삭제

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizPageController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizPageController.java
@@ -3,8 +3,6 @@ package com.example.cs25service.domain.quiz.controller;
 import com.example.cs25common.global.dto.ApiResponse;
 import com.example.cs25service.domain.quiz.dto.TodayQuizResponseDto;
 import com.example.cs25service.domain.quiz.service.QuizPageService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,14 +16,9 @@ public class QuizPageController {
 
     @GetMapping("/todayQuiz")
     public ApiResponse<TodayQuizResponseDto> showTodayQuizPage(
-        HttpServletResponse response,
         @RequestParam("subscriptionId") String subscriptionId,
         @RequestParam("quizId") String quizId
     ) {
-        Cookie cookie = new Cookie("subscriptionId", subscriptionId);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
 
         return new ApiResponse<>(
             200,


### PR DESCRIPTION
## 🔎 작업 내용

- 쿠키로 저장되는 subscriptionId 값이 다른 곳에 쓸모가없어서 저장안되도록 수정

---

## 🛠️ 변경 사항

- 

---

## 🧩 트러블 슈팅

- 

---

## 🧯 해결해야 할 문제

- 

---

## 📌 참고 사항

- 

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인
