### PR TITLE
chore: QuizPageService @Transactional readonly 설정하여 조회성능 향상

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
@@ -10,9 +10,11 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class QuizPageService {
 
     private final QuizRepository quizRepository;


### PR DESCRIPTION

---

## 🔎 작업 내용

- `QuizPageService`은 조회만 하는 서비스로직이기 때문에 조회성능 향상을 위해서
`readOnly=true` 설정을 하였음



### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타**
  * 퀴즈 서비스의 데이터 조회 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->