### PR TITLE
Refactor/310 : Ai피드백 Thread Woker 수 오토 스케일링 조절 리팩토링

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Build & Test
+q1name: CI - Build & Test
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-q1name: CI - Build & Test
+name: CI - Build & Test
 
 on:
   pull_request:

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
@@ -6,10 +6,13 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -42,7 +45,9 @@ public class AiFeedbackStreamWorker {
         new LinkedBlockingQueue<>()
     );
 
+    private final ScheduledExecutorService scailingExecutor = Executors.newSingleThreadScheduledExecutor();
     private final AtomicBoolean running = new AtomicBoolean(true);
+    private final AtomicInteger consumerCounter = new AtomicInteger(0);
 
     @PostConstruct
     public void start() {
@@ -51,39 +56,44 @@ public class AiFeedbackStreamWorker {
 
         // 초기 워커 실행
         for (int i = 0; i < CORE_WORKER; i++) {
-            final String consumerName = "consumer-" + i;
+            final String consumerName = "consumer-" + consumerCounter.getAndIncrement();
             executor.submit(() -> poll(consumerName));
         }
 
-        // 자동 스케일링 워커 실행
-        executor.submit(this::autoScaleWorkers);
+        // 스케일링 워커를 별도 스케줄러에서 실행
+        scailingExecutor.scheduleWithFixedDelay(this::autoScaleWorkers, 0, SCALING_CHECK_INTERVAL,
+            TimeUnit.SECONDS);
     }
 
     private void autoScaleWorkers() {
-        while (running.get()) {
-            try {
-                long queueSize = redisTemplate.opsForStream().size(RedisStreamConfig.STREAM_KEY);
+        if (!running.get()) {
+            return;
+        }
+        try {
+            long queueSize = redisTemplate.opsForStream().size(RedisStreamConfig.STREAM_KEY);
+
+            synchronized (this) {
                 int currentThreads = executor.getCorePoolSize();
                 int targetThreads = calculateTargetWorkerCount(queueSize);
 
                 if (targetThreads > currentThreads) {
                     // 워커 확장
-                    log.info("워커 수 확장: {}개 -> {}개 (큐 크기: {})", currentThreads, targetThreads, queueSize);
+                    log.info("워커 수 확장: {}개 -> {}개 (큐 크기: {})", currentThreads, targetThreads,
+                        queueSize);
                     executor.setCorePoolSize(targetThreads);
                     for (int i = currentThreads; i < targetThreads; i++) {
-                        final String consumerName = "consumer-" + i;
+                        final String consumerName = "consumer-" + consumerCounter.getAndIncrement();
                         executor.submit(() -> poll(consumerName));
                     }
                 } else if (targetThreads < currentThreads) {
                     // 워커 축소 (setCorePoolSize 감소)
-                    log.info("워커 수 축소: {}개 -> {}개 (큐 크기: {})", currentThreads, targetThreads, queueSize);
+                    log.info("워커 수 축소: {}개 -> {}개 (큐 크기: {})", currentThreads, targetThreads,
+                        queueSize);
                     executor.setCorePoolSize(targetThreads);
                 }
-
-                TimeUnit.SECONDS.sleep(SCALING_CHECK_INTERVAL);
-            } catch (Exception e) {
-                log.error("워커 자동 스케일링 중 오류 발생", e);
             }
+        } catch (Exception e) {
+            log.error("워커 자동 스케일링 중 오류 발생", e);
         }
     }
 
@@ -91,10 +101,15 @@ public class AiFeedbackStreamWorker {
      * 큐 크기에 따른 목표 워커 수 계산
      */
     private int calculateTargetWorkerCount(long queueSize) {
-        if (queueSize > 1000) return 16;
-        else if (queueSize > 500) return 8;
-        else if (queueSize > 100) return 4;
-        else return CORE_WORKER;
+        if (queueSize > 1000) {
+            return 16;
+        } else if (queueSize > 500) {
+            return 8;
+        } else if (queueSize > 100) {
+            return 4;
+        } else {
+            return CORE_WORKER;
+        }
     }
 
     private void poll(String consumerName) {
@@ -103,7 +118,8 @@ public class AiFeedbackStreamWorker {
                 List<MapRecord<String, Object, Object>> messages = redisTemplate.opsForStream()
                     .read(Consumer.from(GROUP_NAME, consumerName),
                         StreamReadOptions.empty().count(1).block(Duration.ofSeconds(2)),
-                        StreamOffset.create(RedisStreamConfig.STREAM_KEY, ReadOffset.lastConsumed()));
+                        StreamOffset.create(RedisStreamConfig.STREAM_KEY,
+                            ReadOffset.lastConsumed()));
 
                 if (messages != null) {
                     for (MapRecord<String, Object, Object> message : messages) {
@@ -113,14 +129,17 @@ public class AiFeedbackStreamWorker {
                         if (emitter == null) {
                             log.warn("해당 answerId={}에 대한 emitter가 없습니다.", answerId);
                             redisTemplate.opsForStream()
-                                .acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME, message.getId());
+                                .acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME,
+                                    message.getId());
                             continue;
                         }
 
                         processor.stream(answerId, emitter);
                         emitterRegistry.remove(answerId);
-                        redisTemplate.opsForSet().remove(AiFeedbackQueueService.DEDUPLICATION_SET_KEY, answerId);
-                        redisTemplate.opsForStream().acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME, message.getId());
+                        redisTemplate.opsForSet()
+                            .remove(AiFeedbackQueueService.DEDUPLICATION_SET_KEY, answerId);
+                        redisTemplate.opsForStream()
+                            .acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME, message.getId());
                     }
                 }
             } catch (Exception e) {
@@ -133,12 +152,17 @@ public class AiFeedbackStreamWorker {
     public void stop() {
         running.set(false);
         executor.shutdown();
+        scailingExecutor.shutdown();
         try {
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 executor.shutdownNow();
             }
+            if (!scailingExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                scailingExecutor.shutdown();
+            }
         } catch (InterruptedException e) {
             executor.shutdownNow();
+            scailingExecutor.shutdown();
             Thread.currentThread().interrupt();
         }
     }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
@@ -8,6 +8,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
@@ -26,21 +28,59 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class AiFeedbackStreamWorker {
 
-    private static final String GROUP_NAME = RedisStreamConfig.GROUP_NAME;
-    private static final int WORKER_COUNT = 16;
+    private final String GROUP_NAME = RedisStreamConfig.GROUP_NAME;
+    private final int CORE_WORKER = 2; // 기본 워커
+    private final int MAX_WOKRER = 16; // 최대 워커
+    private final int SCALING_CHECK_INTERVAL = 5; // 5초마다 큐 상태 확인
 
     private final AiFeedbackStreamProcessor processor;
     private final RedisTemplate<String, Object> redisTemplate;
     private final EmitterRegistry emitterRegistry;
 
-    private final ExecutorService executor = Executors.newFixedThreadPool(WORKER_COUNT);
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+        CORE_WORKER,
+        MAX_WOKRER,
+        60, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>()
+    );
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     @PostConstruct
     public void start() {
-        for (int i = 0; i < WORKER_COUNT; i++) {
+        for (int i = 0; i < CORE_WORKER; i++) {
             final String consumerName = "consumer-" + i;
-            executor.submit(() -> poll(consumerName));
+            executor.submit(()-> poll(consumerName));
+        }
+        executor.submit(this::autoScaleWorkers);
+    }
+
+    private void autoScaleWorkers() {
+        while (running.get()) {
+            try {
+                Long queueSize = redisTemplate.opsForStream()
+                    .size(RedisStreamConfig.STREAM_KEY);
+                int currentThreads = executor.getActiveCount();
+                int newThreads = CORE_WORKER;
+
+                // 큐 크기에 따라 확장 기준 설정
+                if (queueSize > 100) newThreads = 4;
+                if (queueSize > 500) newThreads = 8;
+                if (queueSize > 1000) newThreads = 16;
+
+                // 현재 스레드 수보다 늘려야 하면 워커 추가
+                if (newThreads > currentThreads) {
+                    log.info("워커 수 확장: {}개 -> {}개 (큐 크기: {})", currentThreads, newThreads, queueSize);
+                    for (int i = currentThreads; i < newThreads; i++) {
+                        final String consumerName = "consumer-" + i;
+                        executor.submit(() -> poll(consumerName));
+                    }
+                }
+
+                // 정해진 시간마다 큐 상태 체크
+                TimeUnit.SECONDS.sleep(SCALING_CHECK_INTERVAL);
+            } catch (Exception e) {
+                log.error("워커 자동 확장 중 오류 발생", e);
+            }
         }
     }
 
@@ -50,8 +90,7 @@ public class AiFeedbackStreamWorker {
                 List<MapRecord<String, Object, Object>> messages = redisTemplate.opsForStream()
                     .read(Consumer.from(GROUP_NAME, consumerName),
                         StreamReadOptions.empty().count(1).block(Duration.ofSeconds(2)),
-                        StreamOffset.create(RedisStreamConfig.STREAM_KEY,
-                            ReadOffset.lastConsumed()));
+                        StreamOffset.create(RedisStreamConfig.STREAM_KEY, ReadOffset.lastConsumed()));
 
                 if (messages != null) {
                     for (MapRecord<String, Object, Object> message : messages) {
@@ -59,16 +98,15 @@ public class AiFeedbackStreamWorker {
                         SseEmitter emitter = emitterRegistry.get(answerId);
 
                         if (emitter == null) {
-                            log.warn("No emitter found for answerId: {}", answerId);
+                            log.warn("해당 answerId={}에 대한 emitter 없습니다.", answerId);
                             redisTemplate.opsForStream()
-                                .acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME,
-                                    message.getId());
+                                .acknowledge(RedisStreamConfig.STREAM_KEY, GROUP_NAME, message.getId());
                             continue;
                         }
 
                         processor.stream(answerId, emitter);
-                        emitterRegistry.remove(answerId);
 
+                        emitterRegistry.remove(answerId);
                         redisTemplate.opsForSet()
                             .remove(AiFeedbackQueueService.DEDUPLICATION_SET_KEY, answerId);
 
@@ -77,7 +115,7 @@ public class AiFeedbackStreamWorker {
                     }
                 }
             } catch (Exception e) {
-                log.error("Redis Stream consumer {} error", consumerName, e);
+                log.error("Redis Stream consumer {}에서 오류 발생", consumerName, e);
             }
         }
     }


### PR DESCRIPTION
## 🔎 작업 내용

- Redis Stream 기반 피드백 워커에 **자동 스케일링 기능**을 추가
- 기존 고정 16개 스레드 풀에서 **코어 스레드(2개) + 최대 16개 스레드**로 동적 조절되도록 변경

closed #310

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 작업자 스레드 풀이 자동으로 확장 및 축소되어, Redis 스트림 큐의 크기에 따라 처리 성능이 유동적으로 최적화됩니다.
  * 시스템 유휴 시 불필요한 리소스 사용이 줄어들어 효율성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->