### PR TITLE
Refactor/345 Ai FeedBack Worker 동적 워커 축소 종료 조건 도입

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/AiFeedbackStreamWorker.java
@@ -57,7 +57,7 @@ public class AiFeedbackStreamWorker {
         // 초기 워커 실행
         for (int i = 0; i < CORE_WORKER; i++) {
             int index = consumerCounter.getAndIncrement();
-            final String consumerName = "consumer-" + consumerCounter.getAndIncrement();
+            final String consumerName = "consumer-" + index;
             executor.submit(() -> poll(consumerName, index));
         }
 
@@ -84,7 +84,7 @@ public class AiFeedbackStreamWorker {
                     executor.setCorePoolSize(targetThreads);
                     for (int i = currentThreads; i < targetThreads; i++) {
                         int index = consumerCounter.getAndIncrement();
-                        final String consumerName = "consumer-" + consumerCounter.getAndIncrement();
+                        final String consumerName = "consumer-" + index;
                         executor.submit(() -> poll(consumerName, index));
                     }
                 } else if (targetThreads < currentThreads) {
@@ -169,7 +169,7 @@ public class AiFeedbackStreamWorker {
             }
         } catch (InterruptedException e) {
             executor.shutdownNow();
-            scalingExecutor.shutdown();
+            scalingExecutor.shutdownNow();
             Thread.currentThread().interrupt();
         }
     }


### PR DESCRIPTION
## 🔎 작업 내용

- **자동 스케일링 개선**
  - `poll(String consumerName)` → `poll(String consumerName, int workerIndex)`로 변경.
  - 동적으로 종료 가능한 워커를 위한 `workerIndex` 기반 종료 조건 추가.
  - 기존 `corePoolSize`보다 높은 workerIndex를 가진 워커는 즉시 종료.

- **스케일링 스레드 분리**
  - `scailingExecutor` → 오타 수정: `scalingExecutor`로 명명 통일.
  - `ThreadPoolExecutor`와 별도의 `ScheduledExecutorService`로 **스케일링 로직 격리** → 스케일링이 메시지 처리에 방해받지 않도록 설계.

- **중복 인덱스 방지**
  - `consumerCounter.getAndIncrement()`을 한 번만 호출하고, `workerIndex`와 `consumerName`을 모두 안정적으로 할당.


---

Closed #345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 워커 스레드의 동적 확장 및 축소 동작이 개선되어, 필요에 따라 워커가 자동으로 종료될 수 있습니다.
  * 내부 변수명이 일관성 있게 수정되었습니다.

* **기타**
  * 시스템의 안정성과 자원 관리 효율성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->