### PR TITLE
Refactor/349 getTodayQuizBySubscription offset 오류 예외처리 추가

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/TodayQuizService.java
@@ -43,7 +43,7 @@ public class TodayQuizService {
             parentCategoryId);
         double accuracy = accuracyResult != null ? accuracyResult : 100.0;
 
-        Set<Long> sentQuizIds = mailLogRepository.findQuiz_IdBySubscription_Id(subscriptionId);
+        Set<Long> sentQuizIds = mailLogRepository.findDistinctQuiz_IdBySubscription_Id(subscriptionId);
         int quizCount = sentQuizIds.size(); // 사용자가 지금까지 푼 문제 수
 
         // 6. 서술형 주기 판단 (풀이 횟수 기반)

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/repository/MailLogRepository.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/repository/MailLogRepository.java
@@ -23,5 +23,5 @@ public interface MailLogRepository extends JpaRepository<MailLog, Long>,
 
     void deleteAllByIdIn(Collection<Long> ids);
 
-    Set<Long> findQuiz_IdBySubscription_Id(Long subscriptionId);
+    Set<Long> findDistinctQuiz_IdBySubscription_Id(Long subscriptionId);
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizAccuracyCalculateService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizAccuracyCalculateService.java
@@ -42,7 +42,7 @@ public class QuizAccuracyCalculateService {
             parentCategoryId);
         double accuracy = accuracyResult != null ? accuracyResult : 100.0;
 
-        Set<Long> sentQuizIds = mailLogRepository.findQuiz_IdBySubscription_Id(subscriptionId);
+        Set<Long> sentQuizIds = mailLogRepository.findDistinctQuiz_IdBySubscription_Id(subscriptionId);
         int quizCount = sentQuizIds.size(); // 사용자가 지금까지 푼 문제 수
 
         // 6. 서술형 주기 판단 (풀이 횟수 기반)


### PR DESCRIPTION


## 🔎 작업 내용

-  getTodayQuizBySubscription offset 오류 예외처리 추가

---

## 🛠️ 변경 사항

-  offfset 선정시 offset보다 후보군의 퀴즈들 수가 적으면 나오는 오류를 대비해서 해당상황 시에는 가장 앞에있는 퀴즈 다시뽑도록 수정


## 📌 참고 사항

- 테스트안해봄
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 중복된 퀴즈 ID가 반환되는 문제를 해결하여, 각 구독에 대해 중복 없이 퀴즈가 제공됩니다.
  * 퀴즈 조회 시 결과가 없을 경우, 자동으로 첫 번째 퀴즈를 반환하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->