### PR TITLE
chore: 런타임베이스이미지를 Ubuntu 계열로 변경하여 apt-get 명령어가 동작할 수 있게 변경

### DIFF
--- a/cs25-service/Dockerfile
+++ b/cs25-service/Dockerfile
@@ -12,7 +12,7 @@ COPY cs25-common cs25-common/
 
 # 테스트 생략하여 빌드 안정화
 RUN ./gradlew :cs25-service:bootJar --stacktrace --no-daemon
-FROM openjdk:17
+FROM eclipse-temurin:17-jre-jammy
 
 # 메타 정보
 LABEL type="application" module="cs25-service"
@@ -21,12 +21,17 @@ LABEL type="application" module="cs25-service"
 WORKDIR /apps
 
 # Node.js + npm 설치 후, MCP 서버 전역 설치
-RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
-  && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-  && apt-get install -y nodejs \
-  && npm install -g @modelcontextprotocol/server-brave-search \
-  && node -v && npm -v && which server-brave-search \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates gnupg bash \
+ && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && npm install -g @modelcontextprotocol/server-brave-search \
+ && npm cache clean --force \
+ && apt-get purge -y gnupg \
+ && apt-get autoremove -y --purge \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 
 # jar 복사
 COPY --from=builder /build/cs25-service/build/libs/*.jar app.jar


### PR DESCRIPTION

## 🔎 작업 내용

- 서비스 모듈의 런타임 베이스 이미지를 `openjdk-17` → Ubuntu 계열(eclipse-temurin:17-jre-jammy)로 변경

### 런타임 베이스 이미지?
<img width="793" height="236" alt="image" src="https://github.com/user-attachments/assets/fdcf1b8e-0237-425f-a8c7-a3265693f9be" />

---

## 🧩 트러블 슈팅

### 배포 시, apt-get 명령어를 못찾겠다는 예외 발생
<img width="989" height="325" alt="image" src="https://github.com/user-attachments/assets/83ff0c31-1b0d-4bd8-8501-479cd81624c7" />

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
    - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 경량화된 JRE 기반 런타임으로 전환해 안정성과 일관된 실행 환경을 확보
  - 컨테이너 기본 시작 동작을 명시해 배포 후 즉시 실행 가능성 향상
- Chores
  - 불필요한 패키지·캐시 제거로 이미지 크기 축소 및 다운로드 속도 개선
  - 추천 패키지 미설치 등 최적화로 빌드·배포 효율성 향상
  - 기본 노출 포트 8080 선언으로 서비스 연결 구성 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->