### PR TITLE
chore/373 자동 등록 도구 비활성화

### DIFF
--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -65,13 +65,14 @@ spring.ai.chat.client.enabled=false
 # MCP
 spring.ai.mcp.client.enabled=true
 spring.ai.mcp.client.type=SYNC
-spring.ai.mcp.client.request-timeout=30s
+spring.ai.mcp.client.request-timeout=45s
 spring.ai.mcp.client.root-change-notification=false
 # STDIO Connect: Brave Search
 spring.ai.mcp.client.stdio.connections.brave.command=server-brave-search
 spring.ai.mcp.client.stdio.connections.brave.args[0]=--stdio
 spring.ai.mcp.client.stdio.connections.brave.env.BRAVE_API_KEY=${BRAVE_API_KEY}
 spring.ai.mcp.client.initialized=false
+spring.autoconfigure.exclude=org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration
 #MAIL
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587


### PR DESCRIPTION
---

## 🔎 작업 내용
핵심 에러: Client must be initialized before listing tools
호출 경로: ToolCallingAutoConfiguration → SyncMcpToolCallbackProvider.getToolCallbacks() → McpSyncClient.listTools()
- ToolCalling 자동구성 비활성화
---

closed #373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 작업(Chores)
  * MCP 클라이언트 요청 타임아웃을 30초에서 45초로 확장해 장시간 처리 시 성공률과 안정성을 높였습니다. 네트워크 지연이 있는 환경에서 응답 실패(타임아웃) 발생 가능성을 줄입니다.
  * 도구 호출 관련 자동 구성을 제외하여 불필요한 초기화를 방지하고, 애플리케이션 기동 및 런타임 동작의 예측 가능성과 안정성을 개선했습니다. 사용자 기능 변화는 없으며 전반적 신뢰성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->