### PR TITLE
Refactor/402 래퍼스크립트를 만들어 커맨드명 유지하도록 도커파일 수정

### DIFF
--- a/cs25-service/Dockerfile
+++ b/cs25-service/Dockerfile
@@ -22,31 +22,29 @@ LABEL type="application" module="cs25-service"
 # 작업 디렉토리
 WORKDIR /apps
 
-# Node.js + npm 설치 후, MCP 서버 전역 설치 + 심볼릭 링크 생성 + 빌드 타임 확인
+# Node.js 22 설치 + 공식 Brave MCP 서버 설치 + 래퍼 스크립트 생성
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg bash \
- && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  \
- # 1) 전역 설치
- && npm install -g @modelcontextprotocol/server-brave-search \
+ # 공식 패키지 설치 (deprecated 패키지 제거)
+ && npm install -g @brave/brave-search-mcp-server \
  \
- # 2) 전역 prefix/bin 경로 계산 (npm bin -g 대신 npm prefix -g 사용)
+ # 전역 모듈 경로 계산
  && NPM_PREFIX="$(npm prefix -g)" \
- && SRC_BIN="${NPM_PREFIX}/bin/server-brave-search" \
+ && SRCDIR="${NPM_PREFIX}/lib/node_modules/@brave/brave-search-mcp-server" \
  \
- # 3) 심볼릭 링크 생성 (/usr/local/bin 에 고정 경로 제공)
- && ln -sf "${SRC_BIN}" /usr/local/bin/server-brave-search \
+ # 실행 래퍼 스크립트 생성: server-brave-search (STDIO 고정)
+ && printf '#!/usr/bin/env bash\nexec node "%s/dist/index.js" --transport stdio "$@"\n' "$SRCDIR" > /usr/local/bin/server-brave-search \
+ && chmod +x /usr/local/bin/server-brave-search \
  \
- # ===== 실행 가능 여부 확인 =====
- && echo "=== npm prefix -g ===" && echo "${NPM_PREFIX}" \
- && echo "=== 실제 바이너리 위치 확인 ===" && ls -l "${SRC_BIN}" \
- && echo "=== 심볼릭 링크 확인 ===" && ls -l /usr/local/bin/server-brave-search \
- && echo "=== server-brave-search --help 실행 ===" \
- && /usr/local/bin/server-brave-search --help || (echo "[ERROR] server-brave-search 실행 실패" && exit 1) \
+ # 설치/실행 점검
+ && echo "=== which server-brave-search ===" && which server-brave-search \
+ && echo "=== server-brave-search --help ===" && server-brave-search --help || (echo "[ERROR] server-brave-search 실행 실패" && exit 1) \
  \
+ # 정리
  && npm cache clean --force \
- && apt-get purge -y gnupg \
  && apt-get autoremove -y --purge \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## 🔎 작업 내용

- @brave/brave-search-mcp-server + 래퍼 스크립트로 교체

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 없음
* 유지 관리(Chores)
  * 런타임을 Node.js 22로 업데이트했습니다.
  * Brave 검색 MCP 서버를 공식 패키지로 교체하고 실행 방식을 스크립트로 표준화했습니다.
  * server-brave-search 명령어를 STDIO 전송 방식으로 실행하도록 보장하고, 가용성/도움말 확인을 추가했습니다.
  * 불필요한 패키지 정리 절차를 조정해 빌드 정리를 유지했습니다.
* 문서화
  * 설치 및 실행 방식 관련 주석을 최신 권장 사항에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->