### PR TITLE
Refactor/402 : MCP 서버 fix stdio args

### DIFF
--- a/cs25-service/Dockerfile
+++ b/cs25-service/Dockerfile
@@ -22,31 +22,29 @@ LABEL type="application" module="cs25-service"
 # 작업 디렉토리
 WORKDIR /apps
 
-# Node.js + npm 설치 후, MCP 서버 전역 설치 + 심볼릭 링크 생성 + 빌드 타임 확인
+# Node.js 22 설치 + 공식 Brave MCP 서버 설치 + 래퍼 스크립트 생성
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg bash \
- && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  \
- # 1) 전역 설치
- && npm install -g @modelcontextprotocol/server-brave-search \
+ # 공식 패키지 설치 (deprecated 패키지 제거)
+ && npm install -g @brave/brave-search-mcp-server \
  \
- # 2) 전역 prefix/bin 경로 계산 (npm bin -g 대신 npm prefix -g 사용)
+ # 전역 모듈 경로 계산
  && NPM_PREFIX="$(npm prefix -g)" \
- && SRC_BIN="${NPM_PREFIX}/bin/server-brave-search" \
+ && SRCDIR="${NPM_PREFIX}/lib/node_modules/@brave/brave-search-mcp-server" \
  \
- # 3) 심볼릭 링크 생성 (/usr/local/bin 에 고정 경로 제공)
- && ln -sf "${SRC_BIN}" /usr/local/bin/server-brave-search \
+ # 실행 래퍼 스크립트 생성: server-brave-search (STDIO 고정)
+ && printf '#!/usr/bin/env bash\nexec node "%s/dist/index.js" --transport stdio "$@"\n' "$SRCDIR" > /usr/local/bin/server-brave-search \
+ && chmod +x /usr/local/bin/server-brave-search \
  \
- # ===== 실행 가능 여부 확인 =====
- && echo "=== npm prefix -g ===" && echo "${NPM_PREFIX}" \
- && echo "=== 실제 바이너리 위치 확인 ===" && ls -l "${SRC_BIN}" \
- && echo "=== 심볼릭 링크 확인 ===" && ls -l /usr/local/bin/server-brave-search \
- && echo "=== server-brave-search --help 실행 ===" \
- && /usr/local/bin/server-brave-search --help || (echo "[ERROR] server-brave-search 실행 실패" && exit 1) \
+ # 설치/실행 점검
+ && echo "=== which server-brave-search ===" && which server-brave-search \
+ && echo "=== server-brave-search --help ===" && server-brave-search --help || (echo "[ERROR] server-brave-search 실행 실패" && exit 1) \
  \
+ # 정리
  && npm cache clean --force \
- && apt-get purge -y gnupg \
  && apt-get autoremove -y --purge \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/cs25-service/Dockerfile
+++ b/cs25-service/Dockerfile
@@ -35,9 +35,13 @@ RUN apt-get update \
  && NPM_PREFIX="$(npm prefix -g)" \
  && SRCDIR="${NPM_PREFIX}/lib/node_modules/@brave/brave-search-mcp-server" \
  \
- # 실행 래퍼 스크립트 생성: server-brave-search (STDIO 고정)
- && printf '#!/usr/bin/env bash\nexec node "%s/dist/index.js" --transport stdio "$@"\n' "$SRCDIR" > /usr/local/bin/server-brave-search \
- && chmod +x /usr/local/bin/server-brave-search \
+# 실행 래퍼 (args는 전부 "$@"로 위임)
+&& { \
+  echo '#!/bin/sh'; \
+  echo 'NODE=$(command -v node || echo /usr/bin/node)'; \
+  echo 'exec "$NODE" "'"$SRCDIR"'/dist/index.js" "$@"'; \
+} > /usr/local/bin/server-brave-search \
+&& chmod 0755 /usr/local/bin/server-brave-search \
  \
  # 설치/실행 점검
  && echo "=== which server-brave-search ===" && which server-brave-search \

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -69,7 +69,8 @@ spring.ai.mcp.client.request-timeout=60s
 spring.ai.mcp.client.root-change-notification=false
 # STDIO Connect: Brave Search
 spring.ai.mcp.client.stdio.connections.brave.command=server-brave-search
-spring.ai.mcp.client.stdio.connections.brave.args[0]=--stdio
+spring.ai.mcp.client.stdio.connections.brave.args[0]=--transport
+spring.ai.mcp.client.stdio.connections.brave.args[1]=stdio
 spring.ai.mcp.client.stdio.connections.brave.env.BRAVE_API_KEY=${BRAVE_API_KEY}
 spring.ai.mcp.client.initialized=false
 spring.autoconfigure.exclude=org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration


### PR DESCRIPTION
## 🔎 작업 내용

- Dockerfile: 런타임 이미지에 Node 22 설치, @brave/brave-search-mcp-server 글로벌 설치, server-brave-search 래퍼 스크립트 추가.
- application.properties: args[0]=--transport, args[1]=stdio로 공식 문법 적용. (--stdio 단일 플래그 사용하지 않음)

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 서버 실행 스크립트를 bash 의존성 없이 /bin/sh 호환으로 개선해 다양한 환경에서 안정적으로 동작합니다.
  - Node 탐지를 강화해(command -v node → /usr/bin/node 폴백) 실행 실패 가능성을 줄였습니다.
  - 고정된 --transport stdio 옵션을 제거하여 전송 방식 설정이 가능해졌습니다.

- 작업(Chores)
  - 컨테이너 빌드 시 실행 래퍼를 생성하고 실행 권한(0755)을 부여했습니다.
  - 설정의 인자 전달 방식을 정규화해 호환성과 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->