### PR TITLE
Refactor: Json파싱 표준화로 MCP Servie 리팩토링

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/BraveSearchMcpService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/BraveSearchMcpService.java
@@ -2,11 +2,15 @@ package com.example.cs25service.domain.ai.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +24,6 @@ public class BraveSearchMcpService {
     private static final String BRAVE_WEB_TOOL = "brave_web_search";
 
     private final List<McpSyncClient> mcpClients;
-
     private final ObjectMapper objectMapper;
 
     public JsonNode search(String query, int count, int offset) {
@@ -33,22 +36,68 @@ public class BraveSearchMcpService {
 
         CallToolResult result = braveClient.callTool(request);
 
-        JsonNode content = objectMapper.valueToTree(result.content());
-        log.info("[Brave MCP Response Raw content]: {}", content.toPrettyString());
+        // 원본 로그 (디버그용)
+        JsonNode raw = objectMapper.valueToTree(result.content());
+        log.info("[Brave MCP Response Raw content]: {}", raw.toPrettyString());
 
+        // 결과 정규화: results 배열에 {url,title,description}
+        ArrayNode results = objectMapper.createArrayNode();
 
-        if (content != null && content.isArray()) {
-            var root = objectMapper.createObjectNode();
-            root.set("results", content);
-            return root;
+        if (raw != null && raw.isArray()) {
+            for (JsonNode item : raw) {
+                // MCP content 중 text 타입만 처리
+                if ("text".equalsIgnoreCase(item.path("type").asText())) {
+                    String text = item.path("text").asText("").trim();
+                    if (text.isEmpty()) {
+                        continue;
+                    }
+
+                    // 1) 우선 JSON으로 파싱 시도 (대부분 여기서 해결)
+                    if (looksLikeJson(text)) {
+                        parseJsonBlockIntoResults(text, results);
+                        continue;
+                    }
+
+                    // 2) 혹시 text가 "{"url":...}" 같은 JSON 문자열 리터럴로 들어온 경우
+                    //    readTree하면 TextNode가 나오니 한 번 더 벗겨서 재파싱
+                    try {
+                        JsonNode maybeString = objectMapper.readTree(text);
+                        if (maybeString.isTextual() && looksLikeJson(maybeString.asText())) {
+                            parseJsonBlockIntoResults(maybeString.asText(), results);
+                            continue;
+                        }
+                    } catch (Exception ignored) {
+                        // 그냥 패스하고 fallback로
+                    }
+
+                    // 3) Fallback: "Title:..., URL:..., (내용...)" 포맷 처리
+                    addFromTitleUrlBlock(text, results);
+                }
+            }
         }
 
-        return content != null ? content : objectMapper.createObjectNode();
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("results", results);
+        log.info("Brave 검색 결과 {}건 추출", results.size());
+        return root;
     }
 
     private McpSyncClient resolveBraveClient() {
         for (McpSyncClient client : mcpClients) {
-            ListToolsResult tools = client.listTools();
+            ListToolsResult tools;
+            try {
+                tools = client.listTools();
+            } catch (McpError e) {
+                // 초기화 안 된 클라이언트 방어
+                if (e.getMessage() != null &&
+                    e.getMessage().toLowerCase(Locale.ROOT).contains("initialized")) {
+                    client.initialize();
+                    tools = client.listTools();
+                } else {
+                    throw e;
+                }
+            }
+
             if (tools != null && tools.tools() != null) {
                 boolean found = tools.tools().stream()
                     .anyMatch(tool -> BRAVE_WEB_TOOL.equalsIgnoreCase(tool.name()));
@@ -57,7 +106,111 @@ public class BraveSearchMcpService {
                 }
             }
         }
+        throw new IllegalStateException("Brave MCP 서버에서 " + BRAVE_WEB_TOOL + " 툴을 찾을 수 없습니다.");
+    }
 
-        throw new IllegalStateException("Brave MCP 서버에서 brave_web_search 툴을 찾을 수 없습니다.");
+    /* ------------------ helpers ------------------ */
+
+    private boolean looksLikeJson(String s) {
+        String t = s.trim();
+        return (t.startsWith("{") && t.endsWith("}")) || (t.startsWith("[") && t.endsWith("]"));
+    }
+
+    private void parseJsonBlockIntoResults(String json, ArrayNode out) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            if (node.isArray()) {
+                for (JsonNode obj : node) {
+                    addObjToResults(obj, out);
+                }
+            } else if (node.isObject()) {
+                addObjToResults(node, out);
+            } else if (node.isTextual() && looksLikeJson(node.asText())) {
+                // 이중 문자열화된 JSON 방어
+                parseJsonBlockIntoResults(node.asText(), out);
+            }
+        } catch (Exception e) {
+            log.warn("Brave MCP JSON 파싱 실패: {}", truncate(json, 400), e);
+        }
+    }
+
+    private void addObjToResults(JsonNode obj, ArrayNode out) {
+        String url = asStr(obj.get("url"));
+        String title = asStr(obj.get("title"));
+        String description = asStr(firstNonNull(
+            obj.get("description"),
+            obj.get("snippet"),
+            obj.get("summary"),
+            obj.get("content")
+        ));
+
+        // 최소 하나는 있어야 추가
+        if ((url != null && !url.isBlank()) ||
+            (title != null && !title.isBlank()) ||
+            (description != null && !description.isBlank())) {
+            ObjectNode one = objectMapper.createObjectNode();
+            if (url != null) {
+                one.put("url", url);
+            }
+            if (title != null) {
+                one.put("title", title);
+            }
+            if (description != null) {
+                one.put("description", description);
+            }
+            out.add(one);
+        }
+    }
+
+    private JsonNode firstNonNull(JsonNode... nodes) {
+        for (JsonNode n : nodes) {
+            if (n != null && !n.isNull()) {
+                return n;
+            }
+        }
+        return null;
+    }
+
+    private String asStr(JsonNode n) {
+        return (n == null || n.isNull()) ? null : n.asText(null);
+    }
+
+    private void addFromTitleUrlBlock(String text, ArrayNode out) {
+        String[] lines = text.split("\\r?\\n");
+        String title = null;
+        String url = null;
+        StringBuilder body = new StringBuilder();
+
+        for (String line : lines) {
+            if (line.startsWith("Title:")) {
+                // 이전 블럭 flush
+                flushOne(out, title, url, body);
+                title = line.replaceFirst("Title:", "").trim();
+                url = null;
+                body.setLength(0);
+            } else if (line.startsWith("URL:")) {
+                url = line.replaceFirst("URL:", "").trim();
+            } else {
+                body.append(line).append('\n');
+            }
+        }
+        flushOne(out, title, url, body);
+    }
+
+    private void flushOne(ArrayNode out, String title, String url, StringBuilder body) {
+        if (title != null && url != null && body.length() > 0) {
+            ObjectNode one = objectMapper.createObjectNode();
+            one.put("title", title);
+            one.put("url", url);
+            one.put("description", body.toString().trim());
+            out.add(one);
+        }
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null || s.length() <= max) {
+            return s;
+        }
+        return s.substring(0, max) + "...";
     }
 }

--- a/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/BraveSearchRagService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/ai/service/BraveSearchRagService.java
@@ -1,6 +1,7 @@
 package com.example.cs25service.domain.ai.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -13,39 +14,126 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BraveSearchRagService {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     public List<Document> toDocuments(Optional<JsonNode> resultsNodeOpt) {
         List<Document> documents = new ArrayList<>();
-
         resultsNodeOpt.ifPresent(root -> {
-            JsonNode results = root.path("results");
-            if (results != null && results.isArray()) {
-                results.forEach(r -> {
-                    // 정규화된 필드 사용
-                    String title = r.path("title").asText("");
-                    String url = r.path("url").asText("");
-                    String description = r.path("description").asText("");
+            for (JsonNode r : root.path("results")) {
+                // 1) 표준 필드 우선 사용
+                String url = getText(r, "url");
+                String title = getText(r, "title");
+                String description = getText(r, "description");
 
-                    // 예비: 만약 위 값이 비었고 text만 온다면(이중포장 누락 케이스), 텍스트를 본문으로 사용
-                    if (title.isBlank() && description.isBlank() && r.hasNonNull("text")) {
-                        description = r.path("text").asText("");
+                // 2) text 필드가 JSON 문자열일 수 있음
+                if (isBlank(url) && isBlank(title) && isBlank(description)) {
+                    String text = getText(r, "text");
+                    if (!isBlank(text) && looksLikeJson(text)) {
+                        try {
+                            JsonNode inner = objectMapper.readTree(text);
+                            url = isBlank(url) ? getText(inner, "url") : url;
+                            title = isBlank(title) ? getText(inner, "title") : title;
+                            description =
+                                isBlank(description) ? getText(inner, "description") : description;
+                        } catch (Exception ignored) { /* fall back below */ }
                     }
+                }
 
-                    // 간단한 HTML 제거
-                    if (!description.isBlank()) {
-                        description = description.replaceAll("<[^>]+>", "");
+                // 3) 레거시 포맷: "Title:/URL:" 라인 파싱
+                if (isBlank(url) && isBlank(title) && isBlank(description)) {
+                    String text = getText(r, "text");
+                    if (!isBlank(text)) {
+                        ParsedLegacy pl = parseLegacyBlock(text);
+                        if (pl != null) {
+                            url = pl.url != null ? pl.url : url;
+                            title = pl.title != null ? pl.title : title;
+                            description = pl.body != null ? pl.body : description;
+                        }
                     }
+                }
 
-                    if (!title.isBlank() || !description.isBlank()) {
-                        documents.add(new Document(
-                            title.isBlank() ? url : title,
-                            description.isBlank() ? (title.isBlank() ? "" : title) : description,
-                            Map.of("title", title, "url", url)
-                        ));
-                    }
-                });
+                // 4) 아무 것도 없으면 스킵
+                if (isBlank(url) && isBlank(title) && isBlank(description)) {
+                    continue;
+                }
+
+                // 5) Document id는 URL > title 우선
+                String id = !isBlank(url) ? url : title;
+                String body = !isBlank(description) ? description
+                    : (!isBlank(title) ? title : (url != null ? url : ""));
+
+                documents.add(new Document(
+                    id,
+                    body,
+                    Map.of(
+                        "title", title == null ? "" : title,
+                        "url", url == null ? "" : url
+                    )
+                ));
             }
         });
-
         return documents;
+    }
+
+    /* ----------------- helpers ----------------- */
+
+    private String getText(JsonNode n, String field) {
+        return (n != null && n.has(field) && n.get(field).isTextual())
+            ? n.get(field).asText().trim() : null;
+    }
+
+    private boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    private boolean looksLikeJson(String s) {
+        String t = s.trim();
+        return (t.startsWith("{") && t.endsWith("}")) ||
+            (t.startsWith("[") && t.endsWith("]")) ||
+            t.contains("\"url\":") || t.contains("\"title\":") || t.contains("\"description\":");
+    }
+
+    /**
+     * "Title: ..." / "URL: ..." 블록을 관대한 방식으로 파싱
+     */
+    private ParsedLegacy parseLegacyBlock(String text) {
+        if (text == null) {
+            return null;
+        }
+        String[] lines = text.split("\\r?\\n");
+        String title = null, url = null;
+        StringBuilder body = new StringBuilder();
+
+        // "Title:" / "URL:" 키워드는 대소문자 무시 + 앞뒤 공백 관대 처리
+        for (String raw : lines) {
+            String line = raw == null ? "" : raw.trim();
+            if (line.regionMatches(true, 0, "Title:", 0, 6)) {
+                // 이전 누적 flush
+                // (여기서는 단일 레코드만 기대하므로 flush 없이 교체)
+                title = line.substring(6).trim();
+            } else if (line.regionMatches(true, 0, "URL:", 0, 4)) {
+                url = line.substring(4).trim();
+            } else {
+                body.append(line).append('\n');
+            }
+        }
+        String desc = body.toString().trim();
+        if (isBlank(title) && isBlank(url) && isBlank(desc)) {
+            return null;
+        }
+        return new ParsedLegacy(title, url, desc);
+    }
+
+    private static class ParsedLegacy {
+
+        final String title;
+        final String url;
+        final String body;
+
+        ParsedLegacy(String title, String url, String body) {
+            this.title = title;
+            this.url = url;
+            this.body = body;
+        }
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- BraveSearchRagService : 먼저 구조화된 결과(url/title/description)를 우선 처리하고 없으면 기존 “Title:, URL:” 텍스트 포맷 파서로 fallback
- BraveSearchMcpService : listTools() 호출 시 초기화 에러면 initialize()로 복구
callTool(...).content()에서 type=text의 text 값을 꺼내 JSON으로 재파싱
결과를 통일된 results: [ {url,title,description} ... ] 형태로 반환

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 검색 결과를 항상 단일 "results" 배열로 표준화해 일관된 출력 제공
  - 각 결과에서 url/title/description을 우선 추출하고, 비어있으면 내부 JSON 또는 레거시 블록을 해석해 단일 문서로 생성
  - 결과별 단건 문서 생성 흐름으로 불필요한 누적 제거

- Bug Fixes
  - Brave 도구 초기화 오류 감지 시 자동 초기화 후 재시도로 실패 감소
  - 중첩 JSON·비정형 레거시 형식에 대한 재귀적 정규화 강화로 누락·깨짐 개선
  - 빈 항목은 건너뛰어 무의미한 결과 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->