### PR TITLE
Refactor/338 : Redis와 상호작용 모듈화, ACK 시점 변경, 문제 출제 실패 시 메시지 삭제 추가

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/adapter/RedisStreamsClient.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/adapter/RedisStreamsClient.java
@@ -49,4 +49,7 @@ public class RedisStreamsClient {
         redisTemplate.opsForStream().delete(stream, id);
     }
 
+    public void addDlq(String dlqStream, Map<String, String> message){
+        redisTemplate.opsForStream().add(dlqStream, message);
+    }
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/adapter/RedisStreamsClient.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/adapter/RedisStreamsClient.java
@@ -1,0 +1,52 @@
+package com.example.cs25batch.adapter;
+
+import jakarta.annotation.Nullable;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@RequiredArgsConstructor
+public class RedisStreamsClient {
+
+    private final StringRedisTemplate redisTemplate;
+    private final String stream;
+    private final String group;
+    private final String consumer;
+
+    @Nullable
+    public MapRecord<String, Object, Object> readWithConsumerGroup(Duration blockTimeout) {
+
+        StreamReadOptions options = StreamReadOptions.empty().count(1).block(blockTimeout);
+
+        List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().read(
+            Consumer.from(group, consumer),
+            options,
+            StreamOffset.create(stream, ReadOffset.lastConsumed())
+        );
+
+        return (records == null || records.isEmpty()) ? null : records.get(0);
+    }
+
+    public void ack(String recordId) {
+        redisTemplate.opsForStream().acknowledge(stream, group, RecordId.of(recordId));
+    }
+
+    public void del(String recordId) {
+        redisTemplate.opsForStream().delete(stream, RecordId.of(recordId));
+    }
+
+    public void ackAndDel(String recordId) {
+        RecordId id = RecordId.of(recordId);
+        redisTemplate.opsForStream().acknowledge(stream, group, id);
+        redisTemplate.opsForStream().delete(stream, id);
+    }
+
+}

--- a/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
@@ -1,5 +1,6 @@
 package com.example.cs25batch.aop;
 
+import com.example.cs25batch.adapter.RedisStreamsClient;
 import com.example.cs25batch.batch.dto.MailDto;
 import com.example.cs25entity.domain.mail.entity.MailLog;
 import com.example.cs25entity.domain.mail.enums.MailStatus;
@@ -26,7 +27,7 @@ import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 public class MailLogAspect {
 
     private final MailLogRepository mailLogRepository;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisStreamsClient redisClient;
 
     @Around("execution(* com.example.cs25batch.sender.context.MailSenderContext.send(..))")
     public Object logMailSend(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -66,7 +67,7 @@ public class MailLogAspect {
                     "subscriptionId", subscription.getId().toString(),
                     "quizId", quiz.getId().toString()
                 );
-                redisTemplate.opsForStream().add("quiz-email-retry-stream", retryMessage);
+                redisClient.addDlq("quiz-email-retry-stream", retryMessage);
             }
         }
     }

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
@@ -37,9 +37,8 @@ public class RedisStreamReader implements ItemReader<Map<String, String>> {
     @Override
     public Map<String, String> read() throws InterruptedException {
         //long start = System.currentTimeMillis();
-        Bucket bucket = mailSenderContext.getBucket(strategyKey);
 
-        while (!bucket.tryConsume(1)) {
+        while (!mailSenderContext.tryConsume(strategyKey, 1L)) {
             Thread.sleep(200); //토큰을 얻을 때까지 간격을 두고 재시도
         }
 

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
@@ -1,5 +1,6 @@
 package com.example.cs25batch.batch.component.reader;
 
+import com.example.cs25batch.adapter.RedisStreamsClient;
 import com.example.cs25batch.sender.context.MailSenderContext;
 import io.github.bucket4j.Bucket;
 import java.time.Duration;
@@ -24,14 +25,10 @@ import org.springframework.stereotype.Component;
 @Component("redisConsumeReader")
 public class RedisStreamReader implements ItemReader<Map<String, String>> {
 
-    private static final String STREAM = "quiz-email-stream";
-    private static final String GROUP = "mail-consumer-group";
-    private static final String CONSUMER = "mail-worker";
-
     @Value("${mail.strategy:javaBatchMailSender}")
     private String strategyKey;
 
-    private final StringRedisTemplate redisTemplate;
+    private final RedisStreamsClient redisClient;
     private final MailSenderContext mailSenderContext;
 
     @Override
@@ -42,17 +39,7 @@ public class RedisStreamReader implements ItemReader<Map<String, String>> {
             Thread.sleep(200); //토큰을 얻을 때까지 간격을 두고 재시도
         }
 
-        List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().read(
-            Consumer.from(GROUP, CONSUMER),
-            StreamReadOptions.empty().count(1).block(Duration.ofMillis(500)),
-            StreamOffset.create(STREAM, ReadOffset.lastConsumed())
-        );
-
-        if (records == null || records.isEmpty()) {
-            return null;
-        }
-
-        MapRecord<String, Object, Object> msg = records.get(0);
+        MapRecord<String, Object, Object> msg = redisClient.readWithConsumerGroup(Duration.ofMillis(500));
         //redisTemplate.opsForStream().acknowledge(STREAM, GROUP, msg.getId());
 
         Map<String, String> data = new HashMap<>();

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
@@ -42,6 +42,8 @@ public class RedisStreamReader implements ItemReader<Map<String, String>> {
         MapRecord<String, Object, Object> msg = redisClient.readWithConsumerGroup(Duration.ofMillis(500));
         //redisTemplate.opsForStream().acknowledge(STREAM, GROUP, msg.getId());
 
+        if(msg == null || msg.getValue().isEmpty()) return null;
+
         Map<String, String> data = new HashMap<>();
         Object subscriptionId = msg.getValue().get("subscriptionId");
         if (subscriptionId != null) {
@@ -51,7 +53,6 @@ public class RedisStreamReader implements ItemReader<Map<String, String>> {
 
         //long end = System.currentTimeMillis();
         //log.info("[3. Queue에서 꺼내기] {}ms", end - start);
-
         return data;
     }
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/reader/RedisStreamReader.java
@@ -53,7 +53,7 @@ public class RedisStreamReader implements ItemReader<Map<String, String>> {
         }
 
         MapRecord<String, Object, Object> msg = records.get(0);
-        redisTemplate.opsForStream().acknowledge(STREAM, GROUP, msg.getId());
+        //redisTemplate.opsForStream().acknowledge(STREAM, GROUP, msg.getId());
 
         Map<String, String> data = new HashMap<>();
         Object subscriptionId = msg.getValue().get("subscriptionId");

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/writer/MailWriter.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/writer/MailWriter.java
@@ -8,8 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j

--- a/cs25-batch/src/main/java/com/example/cs25batch/config/RedisStreamsConfig.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/config/RedisStreamsConfig.java
@@ -1,0 +1,19 @@
+package com.example.cs25batch.config;
+
+import com.example.cs25batch.adapter.RedisStreamsClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisStreamsConfig {
+    @Bean
+    public RedisStreamsClient quizEmailStreamsClient(StringRedisTemplate redisTemplate) {
+        return new RedisStreamsClient(
+            redisTemplate,
+            "quiz-email-stream",   // stream 이름
+            "mail-consumer-group", // group
+            "mail-worker"          // consumer
+        );
+    }
+}

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/JavaMailSenderStrategy.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/JavaMailSenderStrategy.java
@@ -28,7 +28,7 @@ public class JavaMailSenderStrategy implements MailSenderStrategy{
     }
 
     @Override
-    public Bucket getBucket() {
-        return bucket;
+    public boolean tryConsume(Long num){
+        return bucket.tryConsume(num);
     }
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/JavaMailSenderStrategy.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/JavaMailSenderStrategy.java
@@ -17,7 +17,7 @@ public class JavaMailSenderStrategy implements MailSenderStrategy{
             .addLimit(
                     Bandwidth.builder()
                             .capacity(4)
-                            .refillGreedy(2, Duration.ofMillis(500))
+                            .refillGreedy(4, Duration.ofMillis(1000))
                             .build()
             )
             .build();

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/MailSenderStrategy.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/MailSenderStrategy.java
@@ -1,10 +1,9 @@
 package com.example.cs25batch.sender;
 
 import com.example.cs25batch.batch.dto.MailDto;
-import io.github.bucket4j.Bucket;
 
 public interface MailSenderStrategy {
     void sendQuizMail(MailDto mailDto);
 
-    Bucket getBucket();
+    boolean tryConsume(Long num);
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/SesMailSenderStrategy.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/SesMailSenderStrategy.java
@@ -29,7 +29,7 @@ public class SesMailSenderStrategy implements MailSenderStrategy{
     }
 
     @Override
-    public Bucket getBucket() {
-        return bucket;
+    public boolean tryConsume(Long num){
+        return bucket.tryConsume(num);
     }
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/SesMailSenderStrategy.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/SesMailSenderStrategy.java
@@ -18,7 +18,7 @@ public class SesMailSenderStrategy implements MailSenderStrategy{
             .addLimit(
                     Bandwidth.builder()
                             .capacity(14)
-                            .refillGreedy(7, Duration.ofMillis(500))
+                            .refillGreedy(14, Duration.ofMillis(1000))
                             .build()
             )
             .build();

--- a/cs25-batch/src/main/java/com/example/cs25batch/sender/context/MailSenderContext.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/sender/context/MailSenderContext.java
@@ -4,7 +4,6 @@ import com.example.cs25batch.batch.dto.MailDto;
 import com.example.cs25batch.sender.MailSenderStrategy;
 import java.util.Map;
 
-import io.github.bucket4j.Bucket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,9 +17,9 @@ public class MailSenderContext {
         strategy.sendQuizMail(dto);
     }
 
-    public Bucket getBucket(String strategyKey) {
+    public boolean tryConsume(String strategyKey, Long num) {
         MailSenderStrategy strategy = getValidStrategy(strategyKey);
-        return strategy.getBucket();
+        return strategy.tryConsume(num);
     }
 
     private MailSenderStrategy getValidStrategy(String strategyKey) {

--- a/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/enums/MailStatus.java
+++ b/cs25-entity/src/main/java/com/example/cs25entity/domain/mail/enums/MailStatus.java
@@ -2,5 +2,6 @@ package com.example.cs25entity.domain.mail.enums;
 
 public enum MailStatus {
     SENT,
-    FAILED
+    FAILED,
+    QUIZ_FAILED
 }


### PR DESCRIPTION

## 🔎 작업 내용

- Reader에서 ACK하던 것을 Writer 시점으로 변경
- 문제 출제 실패 시에도 ACK 및 DEL하도록 변경

---

## 🛠️ 변경 사항

- RedisStreamsClient 생성 후 reader, processor, writer에 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 메일 상태에 QUIZ_FAILED 추가로 실패 유형을 더 명확히 식별 가능
- 개선
  - 메일 전송 실패 시 재처리/격리(DLQ) 흐름 강화로 안정성 향상
  - 전송 속도 제어 정책 조정(동일 TPS 유지, 버스트 특성 개선)으로 처리 균형성 향상
- 리팩터링
  - Redis 스트림 처리 로직을 전용 클라이언트로 통합해 읽기·확인·삭제 흐름 단순화
  - 메일 전송 전략 인터페이스를 소비 여부 반환 방식으로 일원화해 사용성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->