### PR TITLE
Refactor/311 : 메일 발송 실패 트랜잭션 별도 관리

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
@@ -1,6 +1,7 @@
 package com.example.cs25batch.aop;
 
 import com.example.cs25batch.batch.dto.MailDto;
+import com.example.cs25batch.batch.service.MailLogBatchService;
 import com.example.cs25entity.domain.mail.entity.MailLog;
 import com.example.cs25entity.domain.mail.enums.MailStatus;
 import com.example.cs25entity.domain.mail.exception.CustomMailException;
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 @RequiredArgsConstructor
 public class MailLogAspect {
 
+    private final MailLogBatchService mailLogBatchService;
     private final MailLogRepository mailLogRepository;
     private final StringRedisTemplate redisTemplate;
 
@@ -46,19 +48,19 @@ public class MailLogAspect {
         } catch (Exception e){
             status = MailStatus.FAILED;
             caused = e.getMessage();
+            mailLogBatchService.saveFailLog(subscription, quiz, LocalDateTime.now(), caused);
             throw new CustomMailException(MailExceptionCode.EMAIL_SEND_FAILED_ERROR);
         } finally {
-            MailLog mailLog = MailLog.builder()
-                .subscription(subscription)
-                .quiz(quiz)
-                .sendDate(LocalDateTime.now())
-                .status(status)
-                .caused(caused)
-                .build();
-
-            mailLogRepository.save(mailLog);
-            mailLogRepository.flush();
-
+//            MailLog mailLog = MailLog.builder()
+//                .subscription(subscription)
+//                .quiz(quiz)
+//                .sendDate(LocalDateTime.now())
+//                .status(status)
+//                .caused(caused)
+//                .build();
+//
+//            mailLogRepository.save(mailLog);
+//            mailLogRepository.flush();
             if (status == MailStatus.FAILED) {
                 log.info("메일 발송 실패 : subscriptionId - {}, cause - {}", subscription.getId(), caused);
                 Map<String, String> retryMessage = Map.of(

--- a/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
@@ -72,7 +72,12 @@ public class MailLogAspect {
                 redisClient.addDlq("quiz-email-retry-stream", retryMessage);
             }
             else if (status == MailStatus.SENT){
-                mailLogBatchService.saveSuccessLog(subscription, quiz, LocalDateTime.now());
+                try {
+                    mailLogBatchService.saveSuccessLog(subscription, quiz, LocalDateTime.now());
+                } catch (Exception logEx) {
+                    log.warn("메일 성공 로그 저장 실패: subId={}, quizId={}",
+                        subscription.getId(), quiz.getId(), logEx);
+                }
             }
         }
     }

--- a/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/aop/MailLogAspect.java
@@ -71,6 +71,9 @@ public class MailLogAspect {
                 );
                 redisClient.addDlq("quiz-email-retry-stream", retryMessage);
             }
+            else if (status == MailStatus.SENT){
+                mailLogBatchService.saveSuccessLog(subscription, quiz, LocalDateTime.now());
+            }
         }
     }
 }

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/MailLogBatchService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/MailLogBatchService.java
@@ -1,0 +1,34 @@
+package com.example.cs25batch.batch.service;
+
+import com.example.cs25entity.domain.mail.entity.MailLog;
+import com.example.cs25entity.domain.mail.enums.MailStatus;
+import com.example.cs25entity.domain.mail.repository.MailLogRepository;
+import com.example.cs25entity.domain.quiz.entity.Quiz;
+import com.example.cs25entity.domain.subscription.entity.Subscription;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MailLogBatchService {
+
+    private final MailLogRepository mailLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailLog(Subscription subscription,
+        Quiz quiz,
+        LocalDateTime sendDateTime,
+        String cause) {
+        MailLog log = MailLog.builder()
+            .subscription(subscription)
+            .quiz(quiz)
+            .sendDate(sendDateTime)
+            .status(MailStatus.FAILED)
+            .caused(cause)
+            .build();
+        mailLogRepository.save(log);
+    }
+}

--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/service/MailLogBatchService.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/service/MailLogBatchService.java
@@ -31,4 +31,17 @@ public class MailLogBatchService {
             .build();
         mailLogRepository.save(log);
     }
+
+    @Transactional
+    public void saveSuccessLog(Subscription subscription,
+        Quiz quiz,
+        LocalDateTime sendDateTime) {
+        mailLogRepository.save(MailLog.builder()
+            .subscription(subscription)
+            .quiz(quiz)
+            .sendDate(sendDateTime)
+            .status(MailStatus.SENT)
+            .caused(null)
+            .build());
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 청크 기반 트랜잭션으로 메일 성공 로그 저장, 메일 실패 로그는 별도 트랜잭션으로 저장하는 메서드 추가

---

## 🛠️ 변경 사항

- 기존 flush로 저장하던 메일 로그가 배치에 더 적합한 트랜잭션 구성에 따라 저장됨

closed #311 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 이메일 발송 결과(성공/실패)를 체계적으로 기록하는 로직이 추가되어 이력 확인이 쉬워졌습니다.
  - 발송 성공/실패 로그가 안정적인 배치 처리 경로로 기록되어 가시성이 향상되었습니다.
- 버그 수정
  - 일부 상황에서 이메일 발송 결과가 누락되거나 반영이 지연되던 현상을 개선했습니다.
  - 발송 실패 시 원인과 시점을 안정적으로 저장해 재발견이 용이해졌습니다.
- 리팩터링
  - 이메일 로그 저장 흐름을 전용 서비스로 분리하여 안정성과 유지보수성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->