### PR TITLE
feat : 문제 출제 실패 시, 메일 발송 실패 로그 저장 추가

### DIFF
--- a/cs25-batch/src/main/java/com/example/cs25batch/batch/component/processor/MailConsumerAsyncProcessor.java
+++ b/cs25-batch/src/main/java/com/example/cs25batch/batch/component/processor/MailConsumerAsyncProcessor.java
@@ -2,11 +2,13 @@ package com.example.cs25batch.batch.component.processor;
 
 import com.example.cs25batch.adapter.RedisStreamsClient;
 import com.example.cs25batch.batch.dto.MailDto;
+import com.example.cs25batch.batch.service.MailLogBatchService;
 import com.example.cs25batch.batch.service.TodayQuizService;
 import com.example.cs25entity.domain.quiz.entity.Quiz;
 import com.example.cs25entity.domain.quiz.exception.QuizException;
 import com.example.cs25entity.domain.subscription.entity.Subscription;
 import com.example.cs25entity.domain.subscription.repository.SubscriptionRepository;
+import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ public class MailConsumerAsyncProcessor implements ItemProcessor<Map<String, Str
     private final SubscriptionRepository subscriptionRepository;
     private final TodayQuizService todayQuizService;
     private final RedisStreamsClient redisClient;
+    private final MailLogBatchService mailLogBatchService;
 
     @Override
     public MailDto process(Map<String, String> message) throws Exception {
@@ -49,6 +52,7 @@ public class MailConsumerAsyncProcessor implements ItemProcessor<Map<String, Str
                 .build();
         } catch(QuizException e){
             //문제 출제 실패로 인한 예외 발생 시, 기존 Queue에 있는 데이터 삭제
+            mailLogBatchService.saveFailLog(subscription, null, LocalDateTime.now(), "No quizzes available");
             redisClient.ackAndDel(recordId);
             return null;
         }

--- a/cs25-batch/src/main/resources/application.properties
+++ b/cs25-batch/src/main/resources/application.properties
@@ -44,3 +44,5 @@ server.forward-headers-strategy=framework
 mail.strategy=sesMailSender
 #mail.strategy=javaBatchMailSender
 server.error.whitelabel.enabled=false
+
+spring.batch.job.name = mailConsumerAsyncJob

--- a/cs25-batch/src/main/resources/application.properties
+++ b/cs25-batch/src/main/resources/application.properties
@@ -44,5 +44,3 @@ server.forward-headers-strategy=framework
 mail.strategy=sesMailSender
 #mail.strategy=javaBatchMailSender
 server.error.whitelabel.enabled=false
-
-spring.batch.job.name = mailConsumerAsyncJob


### PR DESCRIPTION
## 🔎 작업 내용

- 별도의 트랜잭션으로 메일 발송 실패 로그를 저장하던 메서드를 Processor에 적용
- 출제할 문제가 없어서 실패 시, caused = No quizzes available 로 저장됨



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 퀴즈가 없는 날 발생하던 메일 처리 예외를 명확히 처리하고 실패 상황을 기록하도록 개선했습니다. 중복 시도와 대기열 잔류를 줄여 메일 발송 흐름의 안정성을 높였습니다.
  * 에러 발생 시 처리 완료와 정리 절차를 보장하여 간헐적 지연 및 누락 가능성을 낮췄습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->