### PR TITLE
refactor: answerNumber , answer 값 AES 대칭키 적용

### DIFF
--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizTestController.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/controller/QuizTestController.java
@@ -1,9 +1,13 @@
 package com.example.cs25service.domain.quiz.controller;
 
 import com.example.cs25common.global.dto.ApiResponse;
+import com.example.cs25service.domain.quiz.dto.TodayQuizResponseDto;
 import com.example.cs25service.domain.quiz.service.QuizAccuracyCalculateService;
+import com.example.cs25service.domain.quiz.service.QuizPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuizTestController {
 
     private final QuizAccuracyCalculateService accuracyService;
+    private final QuizPageService quizPageService;
 
     @GetMapping("/accuracyTest")
     public ApiResponse<Void> accuracyTest() {
@@ -25,6 +30,17 @@ public class QuizTestController {
 //    ) {
 //        accuracyService.getTodayQuizBySubscription(subscriptionId);
 //        return new ApiResponse<>(200);
+//    }
+
+//    @GetMapping("/test/todayQuiz")
+//    public ApiResponse<TodayQuizResponseDto> showTodayQuizPage(
+//            @RequestParam("quizId") String quizId
+//    ) {
+//
+//        return new ApiResponse<>(
+//                200,
+//                quizPageService.showTodayQuizPage(quizId)
+//        );
 //    }
 
 //    @GetMapping("/test/sse")

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/service/QuizPageService.java
@@ -8,6 +8,8 @@ import com.example.cs25service.domain.quiz.dto.QuizCategoryResponseDto;
 import com.example.cs25service.domain.quiz.dto.TodayQuizResponseDto;
 import java.util.Arrays;
 import java.util.List;
+
+import com.example.cs25service.domain.quiz.util.AesUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizPageService {
 
     private final QuizRepository quizRepository;
-
+    private final AesUtil aesUtil;
     /**
      * 오늘의 문제를 반환해주는 메서드
      * @param quizId 문제 id
@@ -56,8 +58,8 @@ public class QuizPageService {
             .choice2(choices.get(1))
             .choice3(choices.get(2))
             .choice4(choices.get(3))
-            .answerNumber(answerNumber)
-            .commentary(quiz.getCommentary())
+            .answerNumber(aesUtil.encrypt(answerNumber))
+            .commentary(aesUtil.encrypt(quiz.getCommentary()))
             .quizType(quiz.getType().name())
             .quizLevel(quiz.getLevel().name())
             .category(getQuizCategory(quiz))
@@ -74,8 +76,8 @@ public class QuizPageService {
         return TodayQuizResponseDto.builder()
             .question(quiz.getQuestion())
             .quizType(quiz.getQuestion())
-            .answer(quiz.getAnswer())
-            .commentary(quiz.getCommentary())
+            .answer(aesUtil.encrypt(quiz.getAnswer()))
+            .commentary(aesUtil.encrypt(quiz.getCommentary()))
             .quizType(quiz.getType().name())
             .quizLevel(quiz.getLevel().name())
             .category(getQuizCategory(quiz))

--- a/cs25-service/src/main/java/com/example/cs25service/domain/quiz/util/AesUtil.java
+++ b/cs25-service/src/main/java/com/example/cs25service/domain/quiz/util/AesUtil.java
@@ -1,0 +1,72 @@
+package com.example.cs25service.domain.quiz.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class AesUtil {
+
+    private final String secretKey;
+
+    public AesUtil(@Value("${aes.secret.key}") String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    private final String ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    private SecretKey getKey() {
+        return new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+    }
+
+    /** 암호화 */
+    public String encrypt(String plainText) {
+        if (plainText == null) return null;
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            byte[] iv = new byte[16];
+            new SecureRandom().nextBytes(iv);
+            IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+            cipher.init(Cipher.ENCRYPT_MODE, getKey(), ivSpec);
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            // IV와 암호문을 Base64로 함께 인코딩
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            throw new RuntimeException("AES encryption error", e);
+        }
+    }
+
+    /** 복호화 */
+    public String decrypt(String cipherText) {
+        if (cipherText == null) return null;
+        try {
+            byte[] decoded = Base64.getDecoder().decode(cipherText);
+
+            byte[] iv = new byte[16];
+            byte[] encrypted = new byte[decoded.length - 16];
+            System.arraycopy(decoded, 0, iv, 0, iv.length);
+            System.arraycopy(decoded, iv.length, encrypted, 0, encrypted.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, getKey(), new IvParameterSpec(iv));
+            byte[] original = cipher.doFinal(encrypted);
+
+            return new String(original, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("AES decryption error", e);
+        }
+    }
+}

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -139,4 +139,4 @@ FRONT_END_URI=https://cs25.co.kr
 #server.servlet.session.cookie.secure=true
 #FRONT_END_URI=http://localhost:5173
 #AES SECRET KEY
-aes.secret.key=1234567890123456
+aes.secret.key=${AES_KEY}

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -138,3 +138,5 @@ FRONT_END_URI=https://cs25.co.kr
 ## JSESSIONID Secure - ??
 #server.servlet.session.cookie.secure=true
 #FRONT_END_URI=http://localhost:5173
+#AES SECRET KEY
+aes.secret.key="123456789123456"

--- a/cs25-service/src/main/resources/application.properties
+++ b/cs25-service/src/main/resources/application.properties
@@ -139,4 +139,4 @@ FRONT_END_URI=https://cs25.co.kr
 #server.servlet.session.cookie.secure=true
 #FRONT_END_URI=http://localhost:5173
 #AES SECRET KEY
-aes.secret.key="123456789123456"
+aes.secret.key=1234567890123456


### PR DESCRIPTION
## 🔎 작업 내용

- 문제 출제 페이지에서 정답、 코멘트가 따로 가려지지않고 노출되던 문제가 있었음。
- 따라서、 ａｎｓｗｅｒ／ｃｏｍｍｅｎｔaｒｙ 두 컬럼에는 프론트와 통신 시 ａｅｓ 대칭키를 적용하도록 함。

---

## 🛠️ 변경 사항

－ 임시 ａｐｉ 만들어서 적용해봤음。현재는 주석처리 되어있음.
- 적용한 AES 대칭키는 AES-16-CBC 임.

<img width="973" height="682" alt="image" src="https://github.com/user-attachments/assets/a2215f73-115d-4c35-a66b-f752ee7cb7d3" />

<img width="1539" height="937" alt="스크린샷 2025-09-26 152610" src="https://github.com/user-attachments/assets/09aec0aa-e378-4554-b379-37fffb9da15c" />


<img width="1012" height="680" alt="image" src="https://github.com/user-attachments/assets/7849f1e9-e002-42f3-be53-b839bf8be6c2" />

<img width="1534" height="708" alt="스크린샷 2025-09-26 152711" src="https://github.com/user-attachments/assets/4aae486a-1321-49b2-a930-d2905e9ee923" />

---

## 📌 참고 사항
- https://velog.io/@tofha054/AES%EB%A5%BC-%EC%9D%B8%ED%84%B0%EB%84%B7-%EA%B8%81%EC%96%B4%EB%8B%A4-%EC%93%B0%EC%A7%80%EB%A7%90%EB%9D%BC%EA%B3%A0
- application.properties에서 임시 키값 16자리 적용해놨는데, 추후에 .env파일에 옮겨서 16,32,48키 중에 골라서 사용하면됨.
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 퀴즈의 정답 및 해설 데이터에 AES 기반 암호화를 적용하여 전송 구간 보안을 강화했습니다. 사용자 경험에는 변화가 없습니다.
- **기타**
  - 암호화 키를 위한 환경설정 항목이 추가되었습니다.
  - 향후 기능 확장을 위한 컨트롤러 구성 정리가 포함되었으나 현재 동작에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->